### PR TITLE
Use current patent policy for webappsec CRD boilerplate

### DIFF
--- a/boilerplate/webappsec/status-CRD.include
+++ b/boilerplate/webappsec/status-CRD.include
@@ -44,12 +44,12 @@
 
 <p>
     This document was produced by a group operating under
-    the <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/">W3C Patent Policy</a>.
+    the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
     W3C maintains a <a href="https://www.w3.org/groups/wg/webappsec/ipr" rel=disclosure>public list of any patent disclosures</a>
     made in connection with the deliverables of the group;
     that page also includes instructions for disclosing a patent.
-    An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#def-essential">Essential Claim(s)</a>
-    must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
+    An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential Claim(s)</a>
+    must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 
 <p>
   This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.


### PR DESCRIPTION
Fixes w3c/webappsec-mixed-content#68