### PR TITLE
Remove boilerplate section about Conformant Algorithms

### DIFF
--- a/boilerplate/w3c/footer.include
+++ b/boilerplate/w3c/footer.include
@@ -36,7 +36,8 @@
                      may be documented in “Tests” blocks like this one.
                      Any such block is non-normative."></wpt>
 
-<div include-if="w3c/ED, w3c/WD, w3c/FPWD, w3c/LCWD, w3c/CR, w3c/CRD, w3c/PR, w3c/REC, w3c/PER, text macro: ALGO-CONFORMANCE">
+<section include-if="w3c/ED, w3c/WD, w3c/FPWD, w3c/LCWD, w3c/CR, w3c/CRD, w3c/PR, w3c/REC, w3c/PER, text macro: ALGO-CONFORMANCE">
+
 <h3 id="w3c-conformant-algorithms" class="no-ref no-num">Conformant Algorithms</h3>
 
     <p>Requirements phrased in the imperative as part of algorithms

--- a/boilerplate/w3c/footer.include
+++ b/boilerplate/w3c/footer.include
@@ -53,7 +53,8 @@
     are intended to be easy to understand
     and are not intended to be performant.
     Implementers are encouraged to optimize.
-</div>
+</section>
+
 </div>
 </body>
 <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>

--- a/boilerplate/w3c/footer.include
+++ b/boilerplate/w3c/footer.include
@@ -36,22 +36,6 @@
                      may be documented in “Tests” blocks like this one.
                      Any such block is non-normative."></wpt>
 
-<h3 id="w3c-conformant-algorithms" class="no-ref no-num">Conformant Algorithms</h3>
-
-    <p>Requirements phrased in the imperative as part of algorithms
-    (such as "strip any leading space characters"
-    or "return false and abort these steps")
-    are to be interpreted with the meaning of the key word
-    ("must", "should", "may", etc)
-    used in introducing the algorithm.
-
-    <p>Conformance requirements phrased as algorithms or specific steps
-    can be implemented in any manner,
-    so long as the end result is equivalent.
-    In particular, the algorithms defined in this specification
-    are intended to be easy to understand
-    and are not intended to be performant.
-    Implementers are encouraged to optimize.
 </div>
 </body>
 <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>

--- a/boilerplate/w3c/footer.include
+++ b/boilerplate/w3c/footer.include
@@ -36,6 +36,24 @@
                      may be documented in “Tests” blocks like this one.
                      Any such block is non-normative."></wpt>
 
+<div include-if="w3c/ED, w3c/WD, w3c/FPWD, w3c/LCWD, w3c/CR, w3c/CRD, w3c/PR, w3c/REC, w3c/PER, text macro: ALGO-CONFORMANCE">
+<h3 id="w3c-conformant-algorithms" class="no-ref no-num">Conformant Algorithms</h3>
+
+    <p>Requirements phrased in the imperative as part of algorithms
+    (such as "strip any leading space characters"
+    or "return false and abort these steps")
+    are to be interpreted with the meaning of the key word
+    ("must", "should", "may", etc)
+    used in introducing the algorithm.
+
+    <p>Conformance requirements phrased as algorithms or specific steps
+    can be implemented in any manner,
+    so long as the end result is equivalent.
+    In particular, the algorithms defined in this specification
+    are intended to be easy to understand
+    and are not intended to be performant.
+    Implementers are encouraged to optimize.
+</div>
 </div>
 </body>
 <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>


### PR DESCRIPTION
This may be appropriate for some documents, but not for all W3C documents, and therefore should not be in the generic boilerplate.

For instance, injecting that into the Process, or Patent Policy, or JLREQ, or the Internationalization glossary… is unwanted.