### PR TITLE
Revert "[csswg] Maintain the hash on redirect."

### DIFF
--- a/boilerplate/csswg/abstract.include
+++ b/boilerplate/csswg/abstract.include
@@ -9,10 +9,7 @@ on screen, on paper, etc.
 const githubPrefix = "https://w3c.github.io/csswg-drafts/";
 if(location.href.slice(0, githubPrefix.length) == githubPrefix) {
 	const suffix = location.href.slice(githubPrefix.length);
-	let draftUrl = "https://drafts.csswg.org/" + suffix;
-	if(location.hash) {
-		draftUrl += "#"+location.hash;
-	}
+	const draftUrl = "https://drafts.csswg.org/" + suffix;
 	window.location.replace(draftUrl);
 }
 </script>

--- a/manifest.txt
+++ b/manifest.txt
@@ -1,4 +1,4 @@
-2023-05-08 18:14:09.347305
+2023-05-05 20:37:09.342276
 d41d8cd98f00b204e9800998ecf8427e boilerplate/logo.include
 7c9882ee1f0773f17801e0d5f8d6a57a boilerplate/footer.include
 d8d0ca96965e06069f5745214f9b3f46 boilerplate/header.include
@@ -37,7 +37,7 @@ f37024a2af88f98a1cd5df08702f9318 boilerplate/audiowg/status-FPWD.include
 a5af14ca8d7c7e30f515bd4bdc1b3228 boilerplate/browser-testing-tools/status-WD.include
 d41d8cd98f00b204e9800998ecf8427e boilerplate/byos/abstract.include
 82b912bb989f75452a28c41a486a2d07 boilerplate/byos/defaults.include
-04fdb3d3773818c0b6d8e400bd35734b boilerplate/csswg/abstract.include
+9a8c53a5f72b89bf8de4519f0f41cb46 boilerplate/csswg/abstract.include
 3feead45e1c1e892a14173747c597ef8 boilerplate/csswg/computed-metadata.include
 985cd1354209c9daf36601b7408e6641 boilerplate/csswg/copyright-DREAM.include
 3fcf1f7845c6a23ca945198f4efe124d boilerplate/csswg/defaults-ED.include


### PR DESCRIPTION
This reverts commit 53bed3c85985d5cd39973389667b54c0611181a9.

It seems that without that change, the behavior is already such that the hash would be maintained across the redirects — but with this change, https://w3c.github.io/csswg-drafts/css-backgrounds/#the-background redirects to https://drafts.csswg.org/css-backgrounds/#the-background##the-background (that is, the hash part gets repeated, and with a doubled ## too).

Given that, it seems completely reverting that change should get the redirects working as expected.