### PR TITLE
Load commit snapshot script with defer to make its DOMContentLoaded listener reliable

### DIFF
--- a/boilerplate/whatwg/header.include
+++ b/boilerplate/whatwg/header.include
@@ -9,7 +9,7 @@
 <link href="https://resources.whatwg.org/standard-shared-with-dev.css" rel="stylesheet">
 <link href="[LOGO]" rel="icon">
 <script src=https://resources.whatwg.org/file-issue.js async></script>
-<script src=https://resources.whatwg.org/commit-snapshot-shortcut-key.js async></script>
+<script src=https://resources.whatwg.org/commit-snapshot-shortcut-key.js defer></script>
 
 <body class="h-entry status-[STATUS]">
 <div class="head">


### PR DESCRIPTION
Changes the load strategy of `commit-snapshot-shortcut-key.js` from `async` to `defer` so that the script's `DOMContentLoaded` listener becomes more reliable. With `defer`, the script is guaranteed to run before `DOMContentLoaded`, while `async` is not.

Related PRs in other spec repos: https://github.com/whatwg/html/pull/9297 and https://github.com/whatwg/whatwg.org/pull/418.