### PR TITLE
Define Bikeshed boilerplate for documents under https://github.com/patcg-individual-drafts.

### DIFF
--- a/boilerplate/patcg-id/copyright.include
+++ b/boilerplate/patcg-id/copyright.include
@@ -1,0 +1,5 @@
+<a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © [YEAR] the Contributors to “[TITLE]”.
+
+This document is licensed under the <a href="https://www.w3.org/copyright/software-license/">W3C Software License</a>.
+
+Contributions to this document are made under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.

--- a/boilerplate/patcg-id/status.include
+++ b/boilerplate/patcg-id/status.include
@@ -1,0 +1,5 @@
+[STATUSTEXT]
+
+<p>This document is an individual draft proposal. It has not been adopted by the <a href="https://patcg.github.io/">Private Advertising Technology Community Group</a>, but it may be discussed in that CG's meetings.
+Please note that under the <a href="http://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a> there is a limited opt-out and other conditions apply.
+Learn more about <a href="http://www.w3.org/community/">W3C Community and Business Groups</a>.</p>


### PR DESCRIPTION
This attempts to start fixing https://github.com/patcg-individual-drafts/private-aggregation-api/issues/59. We'll still need to update the specs' Group from `patcg` to `patcg-id` once this is in. This doesn't remove the W3C branding since the repository operates under the process defined by https://patcg.github.io/charter.html#individual-draft-management. @chrisn, @AramZS, @jkarlin, how do you feel about this?