### PR TITLE
[wg14, wg21] Fix project names

### DIFF
--- a/boilerplate/wg14/defaults.include
+++ b/boilerplate/wg14/defaults.include
@@ -2,6 +2,6 @@
     "Default Highlight": "c"
 ,   "Editor Term": "Author, Authors"
 ,   "Boilerplate": "repository-issue-tracking off"
-,   "!Project": "ISO/IEC JTC1/SC22/WG14 9899: Programming Language — C"
+,   "!Project": "ISO/IEC 9899 Programming Languages — C, ISO/IEC JTC1/SC22/WG14"
 ,   "Favicon": "https://isocpp.org/favicon.ico"
 }

--- a/boilerplate/wg21/defaults.include
+++ b/boilerplate/wg21/defaults.include
@@ -2,6 +2,6 @@
     "Default Highlight": "c++"
 ,   "Editor Term": "Author, Authors"
 ,   "Boilerplate": "repository-issue-tracking off"
-,   "!Project": "ISO/IEC JTC1/SC22/WG21 14882: Programming Language — C++"
+,   "!Project": "ISO/IEC 14882 Programming Languages — C++, ISO/IEC JTC1/SC22/WG21"
 ,   "Favicon": "https://isocpp.org/favicon.ico"
 }


### PR DESCRIPTION
See https://www.iso.org/standard/79358.html and
https://www.iso.org/standard/74528.html for the proper names of the standards.

The working groups are not part of the title of the project, so I moved the working group designations to separate positions.