### PR TITLE
update link to process 2023

### DIFF
--- a/boilerplate/act-rules-format/status-ED.include
+++ b/boilerplate/act-rules-format/status-ED.include
@@ -9,6 +9,6 @@
 
 <p>This document was produced by a group operating under the <a class="css" data-link-type="property" href="https://www.w3.org/Consortium/Patent-Policy-20170801/" id="sotd_patent"><abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="https://www.w3.org/2004/01/pp-impl/35422/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.</p>
 
-<p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+<p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>[STATUSTEXT]

--- a/boilerplate/act-rules-format/status-WD.include
+++ b/boilerplate/act-rules-format/status-WD.include
@@ -13,7 +13,7 @@
 <p>To comment, <a href="https://github.com/w3c/wcag-act/issues/new">file an issue in the <abbr title="World Wide Web Consortium">W3C</abbr> ACT GitHub repository</a>. It is free to create a GitHub account to file issues. If filing issues in GitHub is not feasible, send email to <a href="mailto:public-wcag-act-comments@w3.org?subject=ACT%20Framework%201.0%20public%20comment">public-wcag-act-comments@w3.org</a> (<a href="https://lists.w3.org/Archives/Public/public-wcag-act-comments/">comment archive</a>). Comments are requested by <strong>@@ April 2017</strong>. In-progress updates to the document may be viewed in the <a href="https://w3c.github.io/wcag-act/act-framework.html">publicly visible editors' draft</a>.</p>
 
 <p>This document was published by the <a href="https://www.w3.org/groups/wg/ag">Accessibility Guidelines Working Group</a> as a First Public Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.</p>
 
 <p>Publication as a First Public Working Draft does not imply endorsement by
@@ -21,4 +21,4 @@
 
 <p>This document was produced by a group operating under the <a class="css" data-link-type="property" href="https://www.w3.org/Consortium/Patent-Policy-20170801/" id="sotd_patent"><abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="https://www.w3.org/2004/01/pp-impl/35422/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.</p>
 
-<p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+<p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.

--- a/boilerplate/audiowg/status-CR.include
+++ b/boilerplate/audiowg/status-CR.include
@@ -7,7 +7,7 @@
 	This document was produced by the <a href="https://www.w3.org/groups/wg/audio">Web Audio Working Group</a>
 
 	as a Candidate Recommendation using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 	This document will remain a Candidate Recommendation at least until <time class="status-deadline" datetime="[ISODEADLINE]">[DEADLINE]</time> in order
 	to ensure the opportunity for wide review.
@@ -22,7 +22,7 @@
       Publication as a Candidate Recommendation does not imply endorsement by
       <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
       A Candidate Recommendation Snapshot has received <a
-      href="https://www.w3.org/2021/Process-20210923/#dfn-wide-review">wide review</a>, is intended to
+      href="https://www.w3.org/2023/Process-20230612/#dfn-wide-review">wide review</a>, is intended to
       gather implementation experience, and has commitments from Working Group members to <a
       href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> for implementations.
 
@@ -39,7 +39,7 @@
 	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 
 <p>
-	This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+	This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
 	For changes since the last draft,

--- a/boilerplate/audiowg/status-ED.include
+++ b/boilerplate/audiowg/status-ED.include
@@ -28,7 +28,7 @@
 </p>
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 </p>
 
 <p>

--- a/boilerplate/audiowg/status-FPWD.include
+++ b/boilerplate/audiowg/status-FPWD.include
@@ -10,7 +10,7 @@
   This document was published by the
   the <a href="https://www.w3.org/groups/wg/audio">Web Audio Working Group</a>
   as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 </p>
 
@@ -43,7 +43,7 @@
 </p>
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
 	[STATUSTEXT]

--- a/boilerplate/audiowg/status-WD.include
+++ b/boilerplate/audiowg/status-WD.include
@@ -10,7 +10,7 @@
   This document was published by the
   the <a href="https://www.w3.org/groups/wg/audio">Web Audio Working Group</a>
   as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 </p>
 
@@ -39,7 +39,7 @@
 </p>
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 </p>
 
 <p>

--- a/boilerplate/browser-testing-tools/status-ED.include
+++ b/boilerplate/browser-testing-tools/status-ED.include
@@ -23,7 +23,7 @@
         must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 
 <p>
-        This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+        This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
         [STATUSTEXT]

--- a/boilerplate/browser-testing-tools/status-WD.include
+++ b/boilerplate/browser-testing-tools/status-WD.include
@@ -4,7 +4,7 @@
 
   <p>
     This document was published by the <a href="https://www.w3.org/groups/wg/browser-tools-testing">Browser Testing and Tools Working Group</a> as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
   </p>
 
@@ -22,7 +22,7 @@
   </p>
 
   <p>
-    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>
 
   <p>

--- a/boilerplate/csswg/status.include
+++ b/boilerplate/csswg/status.include
@@ -13,7 +13,7 @@
 	This document was published
 	by the <a href="https://www.w3.org/groups/wg/css">CSS Working Group</a>
 	as a [LONGSTATUS] using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
 	A W3C Recommendation is a specification that, after extensive consensus-building, is endorsed by
       <abbr title="World Wide Web Consortium">W3C</abbr> and its Members,
@@ -24,7 +24,7 @@
 	This document was published
 	by the <a href="https://www.w3.org/groups/wg/css">CSS Working Group</a>
 	as a <strong>Proposed Recommendation</strong> using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
 	Publication as a Proposed Recommendation
 	does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
@@ -33,13 +33,13 @@
 	This document was published
 	by the <a href="https://www.w3.org/groups/wg/css">CSS Working Group</a>
 	as a <strong>Candidate Recommendation Snapshot</strong> using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
 	Publication as a Candidate Recommendation
 	does not imply endorsement by
     <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
 	A Candidate Recommendation Snapshot has received
-	<a href="https://www.w3.org/2021/Process-20211102/#dfn-wide-review">wide review</a>,
+	<a href="https://www.w3.org/2023/Process-20230612/#dfn-wide-review">wide review</a>,
 	is intended to gather implementation experience, and has commitments from Working Group members to <a
       href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> for implementations.
 	This document is intended to become a W3C Recommendation;
@@ -51,7 +51,7 @@
 	This document was published
 	by the <a href="https://www.w3.org/groups/wg/css">CSS Working Group</a>
 	as a <strong>Candidate Recommendation Draft</strong> using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
 	Publication as a Candidate Recommendation
 	does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr>
@@ -64,7 +64,7 @@
 	This document was published
 	by the <a href="https://www.w3.org/groups/wg/css">CSS Working Group</a>
 	as a <strong>Working Draft</strong> using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
 	Publication as a Working Draft
 	does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
@@ -73,7 +73,7 @@
 	This document was published
 	by the <a href="https://www.w3.org/groups/wg/css">CSS Working Group</a>
 	as a <strong>First Public Working Draft</strong> using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
 	Publication as a First Public Working Draft
 	does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
@@ -82,7 +82,7 @@
 	This document was published
 	by the <a href="https://www.w3.org/groups/wg/css">CSS Working Group</a>
 	as a Group Note
-	using the <a href="https://www.w3.org/2021/Process-20211102/#recs-and-notes">Note track</a>.
+	using the <a href="https://www.w3.org/2023/Process-20230612/#recs-and-notes">Note track</a>.
 	Group Notes are not endorsed by W3C nor its Members.
 
 <p include-if="WD, FPWD, CRD">
@@ -100,7 +100,7 @@
 	<a href="mailto:www-style@w3.org?Subject=%5B[SHORTNAME]%5D%20PUT%20SUBJECT%20HERE">www-style@w3.org</a>.
 
 <p>This document is governed by the
-	<a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+	<a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p exclude-if="ED,NOTE">This document was produced by a group operating under the
 	<a href="https://www.w3.org/Consortium/Patent-Policy-20200915/">W3C Patent Policy</a>.

--- a/boilerplate/dap/status-CR.include
+++ b/boilerplate/dap/status-CR.include
@@ -10,7 +10,7 @@
   This document was published by the
   <a href="https://www.w3.org/groups/wg/das">Devices and Sensors Working Group</a>
   as a Candidate Recommendation Snapshot using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
   This document will remain a Candidate Recommendation at least until <time class="status-deadline" datetime="[ISODEADLINE]">[DEADLINE]</time> in order to ensure the opportunity for wide review.
 </p>
@@ -18,7 +18,7 @@
   This document was published by the <a href="https://www.w3.org/groups/wg/das">Devices and Sensors Working Group</a> and
 	the <a href="https://www.w3.org/groups/wg/webapps">Web Applications Working Group</a> 
   as a Candidate Recommendation Snapshot using the <a
-	href="https://www.w3.org/2021/Process-20211102/#recs-and-notes">Recommendation track</a>.
+	href="https://www.w3.org/2023/Process-20230612/#recs-and-notes">Recommendation track</a>.
 	This document is intended to become a W3C Recommendation.
   This document will remain a Candidate Recommendation at least until <time class="status-deadline" datetime="[ISODEADLINE]">[DEADLINE]</time> in order to ensure the opportunity for wide review.
 </p>
@@ -39,7 +39,7 @@
       Publication as a Candidate Recommendation does not imply endorsement by
       <abbr title="World Wide Web Consortium">W3C</abbr> and its Members. 
       A Candidate Recommendation Snapshot has received <a 
-      href="https://www.w3.org/2021/Process-20211102/#dfn-wide-review">wide review</a>, is intended to
+      href="https://www.w3.org/2023/Process-20230612/#dfn-wide-review">wide review</a>, is intended to
       gather implementation experience, and has commitments from Working Group members to <a 
       href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> for implementations.
 </p>
@@ -74,7 +74,7 @@
 </p>
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
 	[STATUSTEXT]

--- a/boilerplate/dap/status-CRD.include
+++ b/boilerplate/dap/status-CRD.include
@@ -10,13 +10,13 @@
   This document was published by the
   <a href="https://www.w3.org/groups/wg/das">Devices and Sensors Working Group</a>
   as a Candidate Recommendation Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 </p>
 <p include-if="Text Macro: JOINTWEBAPPS">
   This document was published by the <a href="https://www.w3.org/groups/wg/das">Devices and Sensors Working Group</a> and
 	the <a href="https://www.w3.org/groups/wg/webapps">Web Applications Working Group</a> as a Candidate Recommendation Draft using the
-	<a href="https://www.w3.org/2021/Process-20211102/#recs-and-notes">Recommendation track</a>.
+	<a href="https://www.w3.org/2023/Process-20230612/#recs-and-notes">Recommendation track</a>.
 	This document is intended to become a W3C Recommendation.
 </p>
 
@@ -71,7 +71,7 @@
 </p>
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
 	[STATUSTEXT]

--- a/boilerplate/dap/status-ED.include
+++ b/boilerplate/dap/status-ED.include
@@ -44,7 +44,7 @@
 </p>
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 </p>
 
 <p>

--- a/boilerplate/dap/status-FPWD.include
+++ b/boilerplate/dap/status-FPWD.include
@@ -10,13 +10,13 @@
   This document was published by the
   <a href="https://www.w3.org/groups/wg/das">Devices and Sensors Working Group</a>
   as a First Public Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 </p>
 <p include-if="Text Macro: JOINTWEBAPPS">
   This document was published by the <a href="https://www.w3.org/groups/wg/das">Devices and Sensors Working Group</a> and
 	the <a href="https://www.w3.org/groups/wg/webapps">Web Applications Working Group</a> as a First Public Working Draft using the
-	<a href="https://www.w3.org/2021/Process-20211102/#recs-and-notes">Recommendation track</a>.
+	<a href="https://www.w3.org/2023/Process-20230612/#recs-and-notes">Recommendation track</a>.
 	This document is intended to become a W3C Recommendation.
 </p>
 
@@ -65,7 +65,7 @@
 </p>
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
 	[STATUSTEXT]

--- a/boilerplate/dap/status-NOTE.include
+++ b/boilerplate/dap/status-NOTE.include
@@ -4,13 +4,13 @@
   This document was published by the
   <a href="https://www.w3.org/groups/wg/das">Devices and Sensors Working Group</a>
   as a Group Note using the <a
-  href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Note
+  href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Note
   track</a>.
 </p>
 <p include-if="Text Macro: JOINTWEBAPPS" data-deliverer="43696, 114929">
   This document was published by the <a href="https://www.w3.org/groups/wg/das">Devices and Sensors Working Group</a> and
 	the <a href="https://www.w3.org/groups/wg/webapps">Web Applications Working Group</a> as a Group Note using the
-	<a href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Note track</a>.
+	<a href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Note track</a>.
 </p>
 
 <p>
@@ -35,7 +35,7 @@
 </p>
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 </p>
 
 <p>

--- a/boilerplate/dap/status-WD.include
+++ b/boilerplate/dap/status-WD.include
@@ -10,13 +10,13 @@
   This document was published by the
   <a href="https://www.w3.org/groups/wg/das">Devices and Sensors Working Group</a>
   as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 </p>
 <p include-if="Text Macro: JOINTWEBAPPS">
   This document was published by the <a href="https://www.w3.org/groups/wg/das">Devices and Sensors Working Group</a> and
 	the <a href="https://www.w3.org/groups/wg/webapps">Web Applications Working Group</a> as a Working Draft using the
-	<a href="https://www.w3.org/2021/Process-20211102/#recs-and-notes">Recommendation track</a>.
+	<a href="https://www.w3.org/2023/Process-20230612/#recs-and-notes">Recommendation track</a>.
 	This document is intended to become a W3C Recommendation.
 </p>
 
@@ -61,7 +61,7 @@
 </p>
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 </p>
 
 <p>

--- a/boilerplate/fxtf/status-CR.include
+++ b/boilerplate/fxtf/status-CR.include
@@ -7,7 +7,7 @@
 	This document was produced by the <a href="https://www.w3.org/groups/wg/css">CSS Working Group</a>
 
 	as a Candidate Recommendation using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 	This document will remain a Candidate Recommendation at least until <time class="status-deadline" datetime="[ISODEADLINE]">[DEADLINE]</time> in order
 	to ensure the opportunity for wide review.
@@ -24,7 +24,7 @@
 	      Publication as a Candidate Recommendation does not imply endorsement by
       <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
       A Candidate Recommendation Snapshot has received <a
-      href="https://www.w3.org/2021/Process-20210923/#dfn-wide-review">wide review</a>, is intended to
+      href="https://www.w3.org/2023/Process-20230612/#dfn-wide-review">wide review</a>, is intended to
       gather implementation experience, and has commitments from Working Group members to <a
       href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> for implementations.
 
@@ -38,7 +38,7 @@
 	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 
 <p>
-	This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+	This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
 	For changes since the last draft,

--- a/boilerplate/fxtf/status-ED.include
+++ b/boilerplate/fxtf/status-ED.include
@@ -26,7 +26,7 @@
 	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 
 <p>
-	This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+	This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
 	[STATUSTEXT]

--- a/boilerplate/fxtf/status-FPWD.include
+++ b/boilerplate/fxtf/status-FPWD.include
@@ -34,6 +34,6 @@
    href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">section
    6 of the W3C Patent Policy</a>.</p>
 
-  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.</p>
+  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.</p>
 
   <p>[STATUSTEXT]

--- a/boilerplate/fxtf/status-LCWD.include
+++ b/boilerplate/fxtf/status-LCWD.include
@@ -39,6 +39,6 @@
    mailing list</strong> as described above. The <strong>deadline for
    comments</strong> is <strong><time class="status-deadline" datetime="[ISODEADLINE]">[DEADLINE]</time></strong>.
 
-  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
   <p>[STATUSTEXT]

--- a/boilerplate/fxtf/status-WD.include
+++ b/boilerplate/fxtf/status-WD.include
@@ -32,6 +32,6 @@
    href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">section
    6 of the W3C Patent Policy</a>.</p>
 
-  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.</p>
+  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.</p>
 
   <p>[STATUSTEXT]

--- a/boilerplate/geolocation/status-ED.include
+++ b/boilerplate/geolocation/status-ED.include
@@ -26,7 +26,7 @@
         must disclose the information in accordance with <a href="http://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
 	[STATUSTEXT]

--- a/boilerplate/gpuwg/status.include
+++ b/boilerplate/gpuwg/status.include
@@ -18,14 +18,14 @@
 
 <p include-if="FPWD,WD">
   This document was published by the <a href="https://www.w3.org/groups/wg/gpu">GPU for the Web Working Group</a> as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
   This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
 </p>
 
 <p include-if="CR">
   This document was published by the <a href="https://www.w3.org/groups/wg/gpu">GPU for the Web Working Group</a> as a Candidate Recommendation using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
   This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
   This document will remain a Candidate Recommendation at least until <time class="status-deadline" datetime="[ISODEADLINE?]">[DEADLINE?]</time> in order to ensure the opportunity for wide review.
@@ -63,7 +63,7 @@
 
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 </p>
 
 

--- a/boilerplate/houdini/status.include
+++ b/boilerplate/houdini/status.include
@@ -13,7 +13,7 @@
 	This document was published
 	by the <a href="https://www.w3.org/groups/wg/css">CSS Working Group</a>
 	as a [LONGSTATUS] using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
 	A W3C Recommendation is a specification that, after extensive consensus-building, is endorsed by
       <abbr title="World Wide Web Consortium">W3C</abbr> and its Members,
@@ -24,7 +24,7 @@
 	This document was published
 	by the <a href="https://www.w3.org/groups/wg/css">CSS Working Group</a>
 	as a <strong>Proposed Recommendation</strong> using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
 	Publication as a Proposed Recommendation
 	does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
@@ -33,13 +33,13 @@
 	This document was published
 	by the <a href="https://www.w3.org/groups/wg/css">CSS Working Group</a>
 	as a <strong>Candidate Recommendation Snapshot</strong> using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
 	Publication as a Candidate Recommendation
 	does not imply endorsement by
     <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
 	A Candidate Recommendation Snapshot has received
-	<a href="https://www.w3.org/2021/Process-20211102/#dfn-wide-review">wide review</a>,
+	<a href="https://www.w3.org/2023/Process-20230612/#dfn-wide-review">wide review</a>,
 	is intended to gather implementation experience, and has commitments from Working Group members to <a
       href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> for implementations.
 	This document is intended to become a W3C Recommendation;
@@ -51,7 +51,7 @@
 	This document was published
 	by the <a href="https://www.w3.org/groups/wg/css">CSS Working Group</a>
 	as a <strong>Candidate Recommendation Draft</strong> using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
 	Publication as a Candidate Recommendation
 	does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr>
@@ -64,7 +64,7 @@
 	This document was published
 	by the <a href="https://www.w3.org/groups/wg/css">CSS Working Group</a>
 	as a <strong>Working Draft</strong> using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
 	Publication as a Working Draft
 	does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
@@ -73,7 +73,7 @@
 	This document was published
 	by the <a href="https://www.w3.org/groups/wg/css">CSS Working Group</a>
 	as a <strong>First Public Working Draft</strong> using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
 	Publication as a Working Draft
 	does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
@@ -93,7 +93,7 @@
 	<a href="mailto:www-style@w3.org?Subject=%5B[SHORTNAME]%5D%20PUT%20SUBJECT%20HERE">www-style@w3.org</a>.
 
 <p>This document is governed by the
-	<a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+	<a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p exclude-if="ED">This document was produced by a group operating under the
 	<a href="https://www.w3.org/Consortium/Patent-Policy-20200915/">W3C Patent Policy</a>.

--- a/boilerplate/html/status-CR.include
+++ b/boilerplate/html/status-CR.include
@@ -9,7 +9,7 @@
   <p>
     This document was published by the <a href="https://www.w3.org/groups/wg/webplatform">Web Platform Working Group</a>
     as a Candidate Recommendation using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 
     Feedback and comments on this specification are welcome. Please use
@@ -26,7 +26,7 @@
           Publication as a Candidate Recommendation does not imply endorsement by
       <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
       A Candidate Recommendation Snapshot has received <a
-      href="https://www.w3.org/2021/Process-20210923/#dfn-wide-review">wide review</a>, is intended to
+      href="https://www.w3.org/2023/Process-20230612/#dfn-wide-review">wide review</a>, is intended to
       gather implementation experience, and has commitments from Working Group members to <a
       href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> for implementations.
   </p>
@@ -45,7 +45,7 @@
     <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
   </p>
   <p>
-    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>
 
   <p>[STATUSTEXT]

--- a/boilerplate/html/status-ED.include
+++ b/boilerplate/html/status-ED.include
@@ -36,7 +36,7 @@
     <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
   </p>
   <p>
-    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>
 
   <p>[STATUSTEXT]

--- a/boilerplate/html/status-LCWD.include
+++ b/boilerplate/html/status-LCWD.include
@@ -9,7 +9,7 @@
   <p>
     This document was published by the <a href="https://www.w3.org/groups/wg/webplatform">Web Platform Working Group</a>
     as a Last Call Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 
     Feedback and comments on this specification are welcome. Please use
@@ -44,7 +44,7 @@
     <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
   </p>
   <p>
-    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>
 
   <p>[STATUSTEXT]

--- a/boilerplate/html/status-PR.include
+++ b/boilerplate/html/status-PR.include
@@ -10,7 +10,7 @@
     This document was published by the
     <a href="https://www.w3.org/groups/wg/webplatform">Web Platform Working Group</a> as a Proposed
     Recommendation using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 
     Feedback and comments on this specification are welcome. Please use
@@ -47,7 +47,7 @@
     <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
   </p>
   <p>
-    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>
 
   <p>[STATUSTEXT]

--- a/boilerplate/html/status-WD.include
+++ b/boilerplate/html/status-WD.include
@@ -8,7 +8,7 @@
   <p>
     This document was published by the <a href="https://www.w3.org/groups/wg/webplatform">Web Platform Working Group</a>
     as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 
     Feedback and comments on this specification are welcome. Please use
@@ -37,7 +37,7 @@
     <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
   </p>
   <p>
-    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>
 
   <p>[STATUSTEXT]

--- a/boilerplate/i18n/status-CR.include
+++ b/boilerplate/i18n/status-CR.include
@@ -6,7 +6,7 @@
 <p>
 	This document was produced by the <a href="https://www.w3.org/groups/wg/i18n-core">Internationalization Working Group</a>
 	as a Candidate Recommendation using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
 	This document is intended to become a W3C Recommendation.
 	This document will remain a Candidate Recommendation at least until <time class="status-deadline" datetime="[ISODEADLINE]">[DEADLINE]</time>
@@ -23,7 +23,7 @@
 	      Publication as a Candidate Recommendation does not imply endorsement by
       <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
       A Candidate Recommendation Snapshot has received <a
-      href="https://www.w3.org/2021/Process-20210923/#dfn-wide-review">wide review</a>, is intended to
+      href="https://www.w3.org/2023/Process-20230612/#dfn-wide-review">wide review</a>, is intended to
       gather implementation experience, and has commitments from Working Group members to <a
       href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> for implementations.
 <p>
@@ -35,7 +35,7 @@
 	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#def-essential">Essential Claim(s)</a>
 	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 
-<p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>. </p>
+<p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>. </p>
 
 <p>
 	For changes since the last draft,

--- a/boilerplate/i18n/status-ED.include
+++ b/boilerplate/i18n/status-ED.include
@@ -21,7 +21,7 @@
 	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 
 <p>
-	This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+	This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
 	[STATUSTEXT]

--- a/boilerplate/i18n/status-FPWD.include
+++ b/boilerplate/i18n/status-FPWD.include
@@ -30,6 +30,6 @@
    href="https://www.w3.org/Consortium/Patent-Policy-20170801/#sec-Disclosure">section
    6 of the W3C Patent Policy</a>.</p>
 
-  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
   <p>[STATUSTEXT]

--- a/boilerplate/i18n/status-WD.include
+++ b/boilerplate/i18n/status-WD.include
@@ -28,6 +28,6 @@
    href="https://www.w3.org/Consortium/Patent-Policy-20170801/#sec-Disclosure">section
    6 of the W3C Patent Policy</a>.</p>
 
-  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
   <p>[STATUSTEXT]

--- a/boilerplate/immersivewebwg/status-CR.include
+++ b/boilerplate/immersivewebwg/status-CR.include
@@ -10,7 +10,7 @@
 
         <p>
             This document was published by the <a href="https://www.w3.org/groups/wg/immersive-web">Immersive Web Working Group</a> as a Candidate Recommendation Snapshot using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
       This document will remain a Candidate Recommendation at least until <time class="status-deadline" datetime="[ISODEADLINE]">[DEADLINE]</time> in order to ensure the opportunity for wide review.
         </p>
@@ -18,7 +18,7 @@
         <p>
             Publication as a Candidate Recommendation does not imply endorsement by
     <abbr title="World Wide Web Consortium">W3C</abbr> and its Members. 
-               A Candidate Recommendation Snapshot has received <a href="https://www.w3.org/2021/Process-20211102/#dfn-wide-review">wide review</a>, is intended to
+               A Candidate Recommendation Snapshot has received <a href="https://www.w3.org/2023/Process-20230612/#dfn-wide-review">wide review</a>, is intended to
           gather implementation experience, and has commitments from Working Group members to <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> for implementations.
         </p>
 <p>
@@ -39,7 +39,7 @@
             6 of the W3C Patent Policy</a>.
         </p>
         <p>
-            This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+            This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
         </p>
 <p>
     For changes since the last draft,

--- a/boilerplate/immersivewebwg/status-CRD.include
+++ b/boilerplate/immersivewebwg/status-CRD.include
@@ -10,7 +10,7 @@
 
         <p>
             This document was published by the <a href="https://www.w3.org/groups/wg/immersive-web">Immersive Web Working Group</a> as a Candidate Recommendation Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
         </p>
 
@@ -39,7 +39,7 @@
             6 of the W3C Patent Policy</a>.
         </p>
         <p>
-            This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+            This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
         </p>
 <p>
     For changes since the last draft,

--- a/boilerplate/immersivewebwg/status-ED.include
+++ b/boilerplate/immersivewebwg/status-ED.include
@@ -31,7 +31,7 @@
     6 of the W3C Patent Policy</a>.
   </p>
   <p>
-    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>
 
   <p>[STATUSTEXT]

--- a/boilerplate/immersivewebwg/status-FPWD.include
+++ b/boilerplate/immersivewebwg/status-FPWD.include
@@ -10,7 +10,7 @@
 
         <p>
             This document was published by the <a href="https://www.w3.org/groups/wg/immersive-web">Immersive Web Working Group</a> as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
         </p>
 
@@ -33,7 +33,7 @@
             6 of the W3C Patent Policy</a>.
         </p>
         <p>
-            This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+            This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
         </p>
         <p>
             [STATUSTEXT]

--- a/boilerplate/immersivewebwg/status-WD.include
+++ b/boilerplate/immersivewebwg/status-WD.include
@@ -10,7 +10,7 @@
 
         <p>
             This document was published by the <a href="https://www.w3.org/groups/wg/immersive-web">Immersive Web Working Group</a> as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
         </p>
 
@@ -29,7 +29,7 @@
             6 of the W3C Patent Policy</a>.
         </p>
         <p>
-            This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+            This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
         </p>
         <p>
             [STATUSTEXT]

--- a/boilerplate/mediacapture/status-CR.include
+++ b/boilerplate/mediacapture/status-CR.include
@@ -9,7 +9,7 @@
 <p>
   This document was published by the <a href="https://www.w3.org/groups/wg/webrtc">Web Real-Time Communications Working Group</a>
   as a Candidate Recommendation using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
   This document will remain a Candidate Recommendation at least until <time class="status-deadline" datetime="[ISODEADLINE]">[DEADLINE]</time> in order
   to ensure the opportunity for wide review.
@@ -26,7 +26,7 @@
         Publication as a Candidate Recommendation does not imply endorsement by
       <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
       A Candidate Recommendation Snapshot has received <a
-      href="https://www.w3.org/2021/Process-20210923/#dfn-wide-review">wide review</a>, is intended to
+      href="https://www.w3.org/2023/Process-20230612/#dfn-wide-review">wide review</a>, is intended to
       gather implementation experience, and has commitments from Working Group members to <a
       href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> for implementations.
 </p>
@@ -50,7 +50,7 @@
 </p>
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
 	[STATUSTEXT]

--- a/boilerplate/mediacapture/status-ED.include
+++ b/boilerplate/mediacapture/status-ED.include
@@ -28,7 +28,7 @@
 </p>
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 </p>
 
 <p>

--- a/boilerplate/mediacapture/status-FPWD.include
+++ b/boilerplate/mediacapture/status-FPWD.include
@@ -10,7 +10,7 @@
   This document was published by the
   the <a href="https://www.w3.org/groups/wg/webrtc">Web Real-Time Communications Working Group</a>
   as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 </p>
 
@@ -43,7 +43,7 @@
 </p>
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
 	[STATUSTEXT]

--- a/boilerplate/mediacapture/status-WD.include
+++ b/boilerplate/mediacapture/status-WD.include
@@ -10,7 +10,7 @@
   This document was published by the
   the <a href="https://www.w3.org/groups/wg/webrtc">Web Real-Time Communications Working Group</a>
   as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 </p>
 
@@ -39,7 +39,7 @@
 </p>
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 </p>
 
 <p>

--- a/boilerplate/mediawg/status.include
+++ b/boilerplate/mediawg/status.include
@@ -23,20 +23,20 @@
 
 <p include-if="FPWD,WD">
   This document was published by the <a href="https://www.w3.org/groups/wg/media">Media Working Group</a> as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
   This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
 </p>
 
 <p include-if="NOTE-FPWD,NOTE-WD">
   This document was published by the <a href="https://www.w3.org/groups/wg/media">Media Working Group</a> as a Group Draft Note using the <a
-    href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Note
+    href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Note
     track</a>.
 </p>
 
 <p include-if="CR">
   This document was published by the <a href="https://www.w3.org/groups/wg/media">Media Working Group</a> as a Candidate Recommendation using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
   This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
   This document will remain a Candidate Recommendation at least until <time class="status-deadline" datetime="[ISODEADLINE?]">[DEADLINE?]</time> in order to ensure the opportunity for wide review.
@@ -44,24 +44,24 @@
 
 <p include-if="NOTE">
   This document was published by the <a href="https://www.w3.org/groups/wg/media">Media Working Group</a> as a Group Note using the <a
-    href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Note
+    href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Note
     track</a>.
 </p>
 
 <p include-if="DRY">
-  This document was published by the <a href="https://www.w3.org/groups/wg/media">Media Working Group</a> as a Draft Registry using the <a href="https://www.w3.org/2021/Process-20211102/#recs-and-notes">Registry track</a>.
+  This document was published by the <a href="https://www.w3.org/groups/wg/media">Media Working Group</a> as a Draft Registry using the <a href="https://www.w3.org/2023/Process-20230612/#recs-and-notes">Registry track</a>.
 </p>
 
 <p include-if="CRY">
-  This document was published by the <a href="https://www.w3.org/groups/wg/media">Media Working Group</a> as a Candidate Registry Snapshot using the <a href="https://www.w3.org/2021/Process-20211102/#recs-and-notes">Registry track</a>.
+  This document was published by the <a href="https://www.w3.org/groups/wg/media">Media Working Group</a> as a Candidate Registry Snapshot using the <a href="https://www.w3.org/2023/Process-20230612/#recs-and-notes">Registry track</a>.
 </p>
 
 <p include-if="CRYD">
-  This document was published by the <a href="https://www.w3.org/groups/wg/media">Media Working Group</a> as a Candidate Registry Draft using the <a href="https://www.w3.org/2021/Process-20211102/#recs-and-notes">Registry track</a>.
+  This document was published by the <a href="https://www.w3.org/groups/wg/media">Media Working Group</a> as a Candidate Registry Draft using the <a href="https://www.w3.org/2023/Process-20230612/#recs-and-notes">Registry track</a>.
 </p>
 
 <p include-if="RY">
-  This document was published by the <a href="https://www.w3.org/groups/wg/media">Media Working Group</a> as a Registry using the <a href="https://www.w3.org/2021/Process-20211102/#recs-and-notes">Registry track</a>.
+  This document was published by the <a href="https://www.w3.org/groups/wg/media">Media Working Group</a> as a Registry using the <a href="https://www.w3.org/2023/Process-20230612/#recs-and-notes">Registry track</a>.
 </p>
 
 
@@ -89,7 +89,7 @@
   Publication as a Candidate Registry Snapshot does not imply endorsement by
     <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
     A Candidate Registry Snapshot has received
-    <a href="https://www.w3.org/2021/Process-20211102/#dfn-wide-review">wide
+    <a href="https://www.w3.org/2023/Process-20230612/#dfn-wide-review">wide
     review</a>.
 </p>
 
@@ -111,7 +111,7 @@
       Publication as a Candidate Recommendation does not imply endorsement by
       <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
       A Candidate Recommendation Snapshot has received <a
-      href="https://www.w3.org/2021/Process-20210923/#dfn-wide-review">wide review</a>, is intended to
+      href="https://www.w3.org/2023/Process-20230612/#dfn-wide-review">wide review</a>, is intended to
       gather implementation experience, and has commitments from Working Group members to <a
       href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> for implementations.
 </p>
@@ -144,7 +144,7 @@
 
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 </p>
 
 

--- a/boilerplate/secondscreenwg/status-ED.include
+++ b/boilerplate/secondscreenwg/status-ED.include
@@ -17,7 +17,7 @@
     Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
   </p>
   <p>
-    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>
 
   <p>[STATUSTEXT]

--- a/boilerplate/secondscreenwg/status-FPWD.include
+++ b/boilerplate/secondscreenwg/status-FPWD.include
@@ -3,7 +3,7 @@
   </p>
   <p>
     This document was published by the <a href="https://www.w3.org/groups/wg/secondscreen">Second Screen Working Group</a> as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
   </p>
   <p>
@@ -21,7 +21,7 @@
     Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
   </p>
   <p>
-    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>
 
   <p>[STATUSTEXT]

--- a/boilerplate/secondscreenwg/status-WD.include
+++ b/boilerplate/secondscreenwg/status-WD.include
@@ -3,7 +3,7 @@
   </p>
   <p>
     This document was published by the <a href="https://www.w3.org/groups/wg/secondscreen">Second Screen Working Group</a> as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
   </p>
   <p>
@@ -18,7 +18,7 @@
     Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
   </p>
   <p>
-    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>
 
   <p>[STATUSTEXT]

--- a/boilerplate/serviceworkers/status-CR.include
+++ b/boilerplate/serviceworkers/status-CR.include
@@ -5,7 +5,7 @@
   <p>
     This document was published by the <a href="https://www.w3.org/groups/wg/service-workers">Service Workers Working Group</a>
     as a Candidate Recommendation using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
     This document will remain a Candidate Recommendation at least until <time class="status-deadline" datetime="[ISODEADLINE]">[DEADLINE]</time> in order
     to ensure the opportunity for wide review.
@@ -21,12 +21,12 @@
           Publication as a Candidate Recommendation does not imply endorsement by
       <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
       A Candidate Recommendation Snapshot has received <a
-      href="https://www.w3.org/2021/Process-20210923/#dfn-wide-review">wide review</a>, is intended to
+      href="https://www.w3.org/2023/Process-20230612/#dfn-wide-review">wide review</a>, is intended to
       gather implementation experience, and has commitments from Working Group members to <a
       href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> for implementations.
   </p>
   <p>
     This document was produced by a group operating under the <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/"><abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="https://www.w3.org/2004/01/pp-impl/101220/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
   </p>
-  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>

--- a/boilerplate/serviceworkers/status-ED.include
+++ b/boilerplate/serviceworkers/status-ED.include
@@ -22,5 +22,5 @@
   <p>
     This document was produced by a group operating under the <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/"><abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="https://www.w3.org/2004/01/pp-impl/101220/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
   </p>
-  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>

--- a/boilerplate/serviceworkers/status-WD.include
+++ b/boilerplate/serviceworkers/status-WD.include
@@ -5,7 +5,7 @@
   <p>
     This document was published by the <a href="https://www.w3.org/groups/wg/service-workers">Service Workers Working Group</a>
     as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
   </p>
 
@@ -22,5 +22,5 @@
   <p>
     This document was produced by a group operating under the <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/"><abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="https://www.w3.org/2004/01/pp-impl/101220/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
   </p>
-  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>

--- a/boilerplate/tag/status-WG-NOTE.include
+++ b/boilerplate/tag/status-WG-NOTE.include
@@ -30,6 +30,6 @@
 
   <p>
     This document is governed by the <a id="w3c_process_revision"
-    href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process
+    href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process
     Document</a>.
   </p>

--- a/boilerplate/texttracks/status-WD.include
+++ b/boilerplate/texttracks/status-WD.include
@@ -16,7 +16,7 @@ evolve.
 <p>This document was published by the <a
 href="https://www.w3.org/AudioVideo/TT/"><abbr title="World Wide Web Consortium">W3C</abbr> Timed
 Text Working Group</a> as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a <abbr
 title="World Wide Web Consortium">W3C</abbr> Recommendation. If you wish to make comments regarding
 this document, please send them to <a
@@ -42,7 +42,7 @@ the start of your email's subject. All comments are welcome.
 	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 </p>
 
 <p>

--- a/boilerplate/uievents/status-WD.include
+++ b/boilerplate/uievents/status-WD.include
@@ -12,7 +12,7 @@
   <p>
     This document was published by the <a href="https://www.w3.org/groups/wg/webapps">Web Applications Working Group</a>
     as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
 
     Feedback and comments on this specification are welcome. Please use
@@ -41,7 +41,7 @@
     <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
   </p>
   <p>
-    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>
 
   <p>[STATUSTEXT]

--- a/boilerplate/wasm/status-ED.include
+++ b/boilerplate/wasm/status-ED.include
@@ -25,7 +25,7 @@
 	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 
 <p>
-	This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+	This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
 	[STATUSTEXT]

--- a/boilerplate/web-payments/status-FPWD.include
+++ b/boilerplate/web-payments/status-FPWD.include
@@ -10,7 +10,7 @@
 
         <p>
             This document was published by the <a href="https://www.w3.org/groups/wg/payments">Web Payments Working Group</a> as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
         </p>
 
@@ -33,7 +33,7 @@
             6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
         </p>
         <p>
-            This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+            This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
         </p>
         <p>
             [STATUSTEXT]

--- a/boilerplate/webapps/status-ED.include
+++ b/boilerplate/webapps/status-ED.include
@@ -28,5 +28,5 @@
   <p>
     This document was produced by a group operating under the <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/"><abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="https://www.w3.org/2004/01/pp-impl/114929/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
   </p>
-  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>

--- a/boilerplate/webapps/status-WD.include
+++ b/boilerplate/webapps/status-WD.include
@@ -12,7 +12,7 @@
   <p>
     This document was published by the <a href="https://www.w3.org/groups/wg/webapps">Web Applications Working Group</a>
     as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
 
     Feedback and comments on this specification are welcome. Please use
@@ -28,5 +28,5 @@
   <p>
     This document was produced by a group operating under the <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/"><abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="https://www.w3.org/2004/01/pp-impl/114929/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
   </p>
-  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>

--- a/boilerplate/webappsec/status-CR.include
+++ b/boilerplate/webappsec/status-CR.include
@@ -9,7 +9,7 @@
   This document was published by the
   <a href="https://www.w3.org/groups/wg/webappsec">Web Application Security Working Group</a>
   as a Candidate Recommendation using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
   This document will remain a Candidate Recommendation at least until <time class="status-deadline" datetime="[ISODEADLINE]">[DEADLINE]</time> in order
   to ensure the opportunity for wide review.
@@ -28,7 +28,7 @@
         Publication as a Candidate Recommendation does not imply endorsement by
       <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
       A Candidate Recommendation Snapshot has received <a
-      href="https://www.w3.org/2021/Process-20210923/#dfn-wide-review">wide review</a>, is intended to
+      href="https://www.w3.org/2023/Process-20230612/#dfn-wide-review">wide review</a>, is intended to
       gather implementation experience, and has commitments from Working Group members to <a
       href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> for implementations.
 
@@ -49,7 +49,7 @@
 	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
 	[STATUSTEXT]

--- a/boilerplate/webappsec/status-CRD.include
+++ b/boilerplate/webappsec/status-CRD.include
@@ -10,7 +10,7 @@
   This document was published by the
   <a href="https://www.w3.org/groups/wg/webappsec">Web Application Security Working Group</a>
   as a Candidate Recommendation Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 </p>
 
@@ -52,7 +52,7 @@
     must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
     [STATUSTEXT]

--- a/boilerplate/webappsec/status-ED.include
+++ b/boilerplate/webappsec/status-ED.include
@@ -32,7 +32,7 @@
 	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
 	[STATUSTEXT]

--- a/boilerplate/webappsec/status-FPWD.include
+++ b/boilerplate/webappsec/status-FPWD.include
@@ -9,7 +9,7 @@
   This document was published by the
   <a href="https://www.w3.org/groups/wg/webappsec">Web Application Security Working Group</a>
   as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 
 <p>
@@ -45,7 +45,7 @@
 	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
 	[STATUSTEXT]

--- a/boilerplate/webappsec/status-LCWD.include
+++ b/boilerplate/webappsec/status-LCWD.include
@@ -9,7 +9,7 @@
   This document was published by the
   <a href="https://www.w3.org/groups/wg/webappsec">Web Application Security Working Group</a>
   as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 
 <p>
@@ -49,7 +49,7 @@
   comments</strong> is <strong><time class="status-deadline" datetime="[ISODEADLINE]">[DEADLINE]</time></strong>.
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
 	[STATUSTEXT]

--- a/boilerplate/webappsec/status-PR.include
+++ b/boilerplate/webappsec/status-PR.include
@@ -9,7 +9,7 @@
   This document was published by the
   <a href="https://www.w3.org/groups/wg/webappsec">Web Application Security Working Group</a>
   as a Proposed Recommendation using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
   The W3C Membership and other interested parties are invited to review the document and
   send comments to <a href="mailto:public-webappsec@w3.org?Subject=%5B[SHORTNAME]%5D%20PUT%20SUBJECT%20HERE">public-webappsec@w3.org</a>
@@ -35,7 +35,7 @@
 	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
 	[STATUSTEXT]

--- a/boilerplate/webappsec/status-WD.include
+++ b/boilerplate/webappsec/status-WD.include
@@ -9,7 +9,7 @@
   This document was published by the
   <a href="https://www.w3.org/groups/wg/webappsec">Web Application Security Working Group</a>
   as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 
 <p>
@@ -42,7 +42,7 @@
 	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
 	[STATUSTEXT]

--- a/boilerplate/webauthn/status-CR.include
+++ b/boilerplate/webauthn/status-CR.include
@@ -19,7 +19,7 @@
   <p>
     This document was published by the <a href="https://www.w3.org/groups/wg/webauthn">Web Authentication Working Group</a>
     as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 
     Feedback and comments on this specification are welcome. Please use
@@ -31,7 +31,7 @@
           Publication as a Candidate Recommendation does not imply endorsement by
       <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
       A Candidate Recommendation Snapshot has received <a
-      href="https://www.w3.org/2021/Process-20210923/#dfn-wide-review">wide review</a>, is intended to
+      href="https://www.w3.org/2023/Process-20230612/#dfn-wide-review">wide review</a>, is intended to
       gather implementation experience, and has commitments from Working Group members to <a
       href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> for implementations.
   </p>
@@ -50,7 +50,7 @@
     <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
   </p>
   <p>
-    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>
 
   <p>[STATUSTEXT]

--- a/boilerplate/webauthn/status-ED.include
+++ b/boilerplate/webauthn/status-ED.include
@@ -36,7 +36,7 @@
     <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
   </p>
   <p>
-    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>
 
   <p>[STATUSTEXT]

--- a/boilerplate/webauthn/status-WD.include
+++ b/boilerplate/webauthn/status-WD.include
@@ -9,7 +9,7 @@
   <p>
     This document was published by the <a href="https://www.w3.org/groups/wg/webauthn">Web Authentication Working Group</a>
     as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 
     Feedback and comments on this specification are welcome. Please use
@@ -38,7 +38,7 @@
     <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
   </p>
   <p>
-    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>
 
   <p>[STATUSTEXT]

--- a/boilerplate/webediting/status-ED.include
+++ b/boilerplate/webediting/status-ED.include
@@ -28,5 +28,5 @@
   <p>
     This document was produced by a group operating under the <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/"><abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="https://www.w3.org/2004/01/pp-impl/114929/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
   </p>
-  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>

--- a/boilerplate/webediting/status-WD.include
+++ b/boilerplate/webediting/status-WD.include
@@ -12,7 +12,7 @@
   <p>
     This document was published by the <a href="https://w3c.github.io/editing/">Web Editing Working Group</a>
     as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
 
     Feedback and comments on this specification are welcome. Please use
@@ -28,5 +28,5 @@
   <p>
     This document was produced by a group operating under the <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/"><abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="https://www.w3.org/2004/01/pp-impl/114929/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
   </p>
-  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>

--- a/boilerplate/webfontswg/status-CR.include
+++ b/boilerplate/webfontswg/status-CR.include
@@ -7,7 +7,7 @@
 	This document was produced by the <a href="https://www.w3.org/groups/wg/webfonts">Web Fonts Working Group</a>
 
 	as a Candidate Recommendation using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 	This document will remain a Candidate Recommendation at least until <time class="status-deadline" datetime="[ISODEADLINE]">[DEADLINE]</time> in order
 	to ensure the opportunity for wide review.
@@ -19,7 +19,7 @@
 	      Publication as a Candidate Recommendation does not imply endorsement by
       <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
       A Candidate Recommendation Snapshot has received <a
-      href="https://www.w3.org/2021/Process-20210923/#dfn-wide-review">wide review</a>, is intended to
+      href="https://www.w3.org/2023/Process-20230612/#dfn-wide-review">wide review</a>, is intended to
       gather implementation experience, and has commitments from Working Group members to <a
       href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> for implementations.
 
@@ -36,7 +36,7 @@
 	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 
 <p>
-	This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+	This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
 	For changes since the last draft,

--- a/boilerplate/webfontswg/status-ED.include
+++ b/boilerplate/webfontswg/status-ED.include
@@ -24,7 +24,7 @@
 </p>
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 </p>
 
 <p>

--- a/boilerplate/webfontswg/status-FPWD.include
+++ b/boilerplate/webfontswg/status-FPWD.include
@@ -9,7 +9,7 @@
 <p>
   This document was produced by the <a href="https://www.w3.org/groups/wg/webfonts">Web Fonts Working Group</a>
   as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 </p>
 
@@ -39,7 +39,7 @@
 </p>
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
 	[STATUSTEXT]

--- a/boilerplate/webfontswg/status-WD.include
+++ b/boilerplate/webfontswg/status-WD.include
@@ -9,7 +9,7 @@
 <p>
   This document was produced by the <a href="https://www.w3.org/groups/wg/webfonts">Web Fonts Working Group</a>
   as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 </p>
 
@@ -35,7 +35,7 @@
 </p>
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 </p>
 
 <p>

--- a/boilerplate/webmlwg/status-CR.include
+++ b/boilerplate/webmlwg/status-CR.include
@@ -2,9 +2,9 @@
 <p>This document was published
 	by the <a href="https://www.w3.org/groups/wg/webmachinelearning">Web Machine Learning Working Group</a>
 	as a <strong>Candidate Recommendation Snapshot</strong> using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
-      <p>Publication as a Candidate Recommendation does not imply endorsement by W3C and its Members. A Candidate Recommendation Snapshot has received <a href="https://www.w3.org/2021/Process-20211102/#dfn-wide-review">wide review</a>, is intended to gather implementation experience, and has commitments from Working Group members to <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> for implementations.</p>
+      <p>Publication as a Candidate Recommendation does not imply endorsement by W3C and its Members. A Candidate Recommendation Snapshot has received <a href="https://www.w3.org/2023/Process-20230612/#dfn-wide-review">wide review</a>, is intended to gather implementation experience, and has commitments from Working Group members to <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> for implementations.</p>
       	<p>This document is intended to become a W3C Recommendation;
 	it will remain a Candidate Recommendation at least until
 	<time class="status-deadline" datetime="[ISODEADLINE?]">[DEADLINE?]</time>
@@ -31,7 +31,7 @@
     <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
   </p>
   <p>
-    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>
 
         <p>

--- a/boilerplate/webmlwg/status-CRD.include
+++ b/boilerplate/webmlwg/status-CRD.include
@@ -2,7 +2,7 @@
 <p>This document was published
 	by the <a href="https://www.w3.org/groups/wg/webmachinelearning">Web Machine Learning Working Group</a>
 	as a <strong>Candidate Recommendation Draft</strong> using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
       <p>Publication as a Candidate Recommendation does not imply endorsement by W3C and its Members. A Candidate Recommendation Draft integrates changes from the previous Candidate Recommendation that the Working Group intends to include in a subsequent Candidate Recommendation Snapshot.</p>
       <p>This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.</p>
@@ -28,7 +28,7 @@
     <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
   </p>
   <p>
-    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>
 
         <p>

--- a/boilerplate/webmlwg/status-ED.include
+++ b/boilerplate/webmlwg/status-ED.include
@@ -35,7 +35,7 @@
     <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
   </p>
   <p>
-    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>
 
   <p>[STATUSTEXT]

--- a/boilerplate/webmlwg/status-FPWD.include
+++ b/boilerplate/webmlwg/status-FPWD.include
@@ -10,7 +10,7 @@
 
         <p>
             This document was published by the <a href="https://www.w3.org/groups/wg/webmachinelearning">Web Machine Learning Working Group</a> as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
         </p>
 
@@ -37,7 +37,7 @@
     <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
   </p>
   <p>
-    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>
         <p>
             [STATUSTEXT]

--- a/boilerplate/webmlwg/status-WD.include
+++ b/boilerplate/webmlwg/status-WD.include
@@ -10,7 +10,7 @@
 
         <p>
             This document was published by the <a href="https://www.w3.org/groups/wg/webmachinelearning">Web Machine Learning Working Group</a> as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
         </p>
 
@@ -33,7 +33,7 @@
     <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
   </p>
   <p>
-    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+    This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
   </p>
         <p>
             [STATUSTEXT]

--- a/boilerplate/webperf/status.include
+++ b/boilerplate/webperf/status.include
@@ -13,7 +13,7 @@
 	This document was published
 	by the <a href="https://www.w3.org/groups/wg/webperf">Web Performance Working Group</a>
 	as a [LONGSTATUS] using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
 	A W3C Recommendation is a specification that, after extensive consensus-building, is endorsed by
       <abbr title="World Wide Web Consortium">W3C</abbr> and its Members,
@@ -24,7 +24,7 @@
 	This document was published
 	by the <a href="https://www.w3.org/groups/wg/webperf">Web Performance Working Group</a>
 	as a <strong>Proposed Recommendation</strong> using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
 	Publication as a Proposed Recommendation
 	does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
@@ -33,13 +33,13 @@
 	This document was published
 	by the <a href="https://www.w3.org/groups/wg/webperf">Web Performance Working Group</a>
 	as a <strong>Candidate Recommendation Snapshot</strong> using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
 	Publication as a Candidate Recommendation
 	does not imply endorsement by
     <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
 	A Candidate Recommendation Snapshot has received
-	<a href="https://www.w3.org/2021/Process-20211102/#dfn-wide-review">wide review</a>,
+	<a href="https://www.w3.org/2023/Process-20230612/#dfn-wide-review">wide review</a>,
 	is intended to gather implementation experience, and has commitments from Working Group members to <a
       href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> for implementations.
 	This document is intended to become a W3C Recommendation;
@@ -51,7 +51,7 @@
 	This document was published
 	by the <a href="https://www.w3.org/groups/wg/webperf">Web Performance Working Group</a>
 	as a <strong>Candidate Recommendation Draft</strong> using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
 	Publication as a Candidate Recommendation
 	does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr>
@@ -64,7 +64,7 @@
 	This document was published
 	by the <a href="https://www.w3.org/groups/wg/webperf">Web Performance Working Group</a>
 	as a <strong>Working Draft</strong> using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
 	Publication as a Working Draft
 	does not imply endorsement by
@@ -74,7 +74,7 @@
 	This document was published
 	by the <a href="https://www.w3.org/groups/wg/webperf">Web Performance Working Group</a>
 	as a <strong>First Public Working Draft</strong> using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>.
 	Publication as a First Public Working Draft
 	does not imply endorsement by
@@ -89,7 +89,7 @@
 <p><a href='https://github.com/[REPOSITORY]/issues'>GitHub Issues</a> are preferred for discussion of this specification.
 
 <p>This document is governed by the
-	<a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+	<a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p exclude-if="ED">This document was produced by a group operating under the
 	<a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.

--- a/boilerplate/webrtc/status-CR.include
+++ b/boilerplate/webrtc/status-CR.include
@@ -10,7 +10,7 @@
   This document was published by the
   <a href="https://www.w3.org/groups/wg/webrtc">Web Real-Time Communications Working Group</a>
   as a Candidate Recommendation using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
   This document will remain a Candidate Recommendation at least until <time class="status-deadline" datetime="[ISODEADLINE]">[DEADLINE]</time> in order
   to ensure the opportunity for wide review.
@@ -32,7 +32,7 @@
       Publication as a Candidate Recommendation does not imply endorsement by
       <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
       A Candidate Recommendation Snapshot has received <a
-      href="https://www.w3.org/2021/Process-20210923/#dfn-wide-review">wide review</a>, is intended to
+      href="https://www.w3.org/2023/Process-20230612/#dfn-wide-review">wide review</a>, is intended to
       gather implementation experience, and has commitments from Working Group members to <a
       href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> for implementations.
 </p>
@@ -55,7 +55,7 @@
 	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
 	[STATUSTEXT]

--- a/boilerplate/webrtc/status-ED.include
+++ b/boilerplate/webrtc/status-ED.include
@@ -33,7 +33,7 @@
 </p>
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 </p>
 
 <p>

--- a/boilerplate/webrtc/status-FPWD.include
+++ b/boilerplate/webrtc/status-FPWD.include
@@ -10,7 +10,7 @@
   This document was published by the
   <a href="https://www.w3.org/groups/wg/webrtc">Web Real-Time Communications Working Group</a>
   as a First Public Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 </p>
 
@@ -47,7 +47,7 @@
 	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
 	[STATUSTEXT]

--- a/boilerplate/webrtc/status-WD.include
+++ b/boilerplate/webrtc/status-WD.include
@@ -10,7 +10,7 @@
   This document was published by the
   <a href="https://www.w3.org/groups/wg/webrtc">Web Real-Time Communications Working Group</a>
   as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 </p>
 
@@ -44,7 +44,7 @@
 </p>
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 </p>
 
 <p>

--- a/boilerplate/webtransport/status-CR.include
+++ b/boilerplate/webtransport/status-CR.include
@@ -10,7 +10,7 @@
   This document was published by the
   <a href="https://www.w3.org/groups/wg/webtransport">WebTransport Working Group</a>
   as a Candidate Recommendation using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
   This document will remain a Candidate Recommendation at least until <time class="status-deadline" datetime="[ISODEADLINE]">[DEADLINE]</time> in order
   to ensure the opportunity for wide review.
@@ -27,7 +27,7 @@
       Publication as a Candidate Recommendation does not imply endorsement by
       <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
       A Candidate Recommendation Snapshot has received <a
-      href="https://www.w3.org/2021/Process-20210923/#dfn-wide-review">wide review</a>, is intended to
+      href="https://www.w3.org/2023/Process-20230612/#dfn-wide-review">wide review</a>, is intended to
       gather implementation experience, and has commitments from Working Group members to <a
       href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> for implementations.
 </p>
@@ -50,7 +50,7 @@
 	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
 	[STATUSTEXT]

--- a/boilerplate/webtransport/status-ED.include
+++ b/boilerplate/webtransport/status-ED.include
@@ -28,7 +28,7 @@
 </p>
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 </p>
 
 <p>

--- a/boilerplate/webtransport/status-FPWD.include
+++ b/boilerplate/webtransport/status-FPWD.include
@@ -10,7 +10,7 @@
   This document was published by the
   <a href="https://www.w3.org/groups/wg/webtransport">WebTransport Working Group</a>
   as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 </p>
 
@@ -42,7 +42,7 @@
 	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 
 <p>
 	[STATUSTEXT]

--- a/boilerplate/webtransport/status-WD.include
+++ b/boilerplate/webtransport/status-WD.include
@@ -10,7 +10,7 @@
   This document was published by the
   <a href="https://www.w3.org/groups/wg/webtransport">WebTransport Working Group</a>
   as a Working Draft using the <a
-      href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
+      href='https://www.w3.org/2023/Process-20230612/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 </p>
 
@@ -39,7 +39,7 @@
 </p>
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C Process Document</a>.
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 W3C Process Document</a>.
 </p>
 
 <p>


### PR DESCRIPTION
Starting from July 17 2023, pubrules will no longer accept documents published under the process 2021.
That PR updates the link with the 2023 process and should be merged on that date.

/cc @plehegar
