### PR TITLE
WHATWG now uses issue templates

### DIFF
--- a/boilerplate/whatwg/computed-metadata-LS-COMMIT.include
+++ b/boilerplate/whatwg/computed-metadata-LS-COMMIT.include
@@ -2,7 +2,7 @@
   "Title": "[SPECTITLE] Standard Commit [COMMIT-SHA] Snapshot",
   "Logo": "https://resources.whatwg.org/logo-[SHORTNAME]-snapshot.svg",
   "!Participate": [
-    "<a href=https://github.com/whatwg/[SHORTNAME]>GitHub whatwg/[SHORTNAME]</a> (<a href=https://github.com/whatwg/[SHORTNAME]/issues/new>new issue</a>, <a href=https://github.com/whatwg/[SHORTNAME]/issues>open issues</a>)",
+    "<a href=https://github.com/whatwg/[SHORTNAME]>GitHub whatwg/[SHORTNAME]</a> (<a href=https://github.com/whatwg/[SHORTNAME]/issues/new/choose>new issue</a>, <a href=https://github.com/whatwg/[SHORTNAME]/issues>open issues</a>)",
     "<a href=https://whatwg.org/chat>Chat on Matrix</a>"
   ],
   "!Commits": [

--- a/boilerplate/whatwg/computed-metadata-LS-PR.include
+++ b/boilerplate/whatwg/computed-metadata-LS-PR.include
@@ -2,7 +2,7 @@
   "Title": "[SPECTITLE] Standard Pull Request #[PR-NUMBER] Preview",
   "Logo": "https://resources.whatwg.org/logo-[SHORTNAME]-snapshot.svg",
   "!Participate": [
-    "<a href=https://github.com/whatwg/[SHORTNAME]>GitHub whatwg/[SHORTNAME]</a> (<a href=https://github.com/whatwg/[SHORTNAME]/issues/new>new issue</a>, <a href=https://github.com/whatwg/[SHORTNAME]/issues>open issues</a>)",
+    "<a href=https://github.com/whatwg/[SHORTNAME]>GitHub whatwg/[SHORTNAME]</a> (<a href=https://github.com/whatwg/[SHORTNAME]/issues/new/choose>new issue</a>, <a href=https://github.com/whatwg/[SHORTNAME]/issues>open issues</a>)",
     "<a href=https://whatwg.org/chat>Chat on Matrix</a>"
   ],
   "!Commits": [

--- a/boilerplate/whatwg/computed-metadata.include
+++ b/boilerplate/whatwg/computed-metadata.include
@@ -2,7 +2,7 @@
   "Title": "[SPECTITLE] Standard",
   "Logo": "https://resources.whatwg.org/logo-[SHORTNAME].svg",
   "!Participate": [
-    "<a href=https://github.com/whatwg/[SHORTNAME]>GitHub whatwg/[SHORTNAME]</a> (<a href=https://github.com/whatwg/[SHORTNAME]/issues/new>new issue</a>, <a href=https://github.com/whatwg/[SHORTNAME]/issues>open issues</a>)",
+    "<a href=https://github.com/whatwg/[SHORTNAME]>GitHub whatwg/[SHORTNAME]</a> (<a href=https://github.com/whatwg/[SHORTNAME]/issues/new/choose>new issue</a>, <a href=https://github.com/whatwg/[SHORTNAME]/issues>open issues</a>)",
     "<a href=https://whatwg.org/chat>Chat on Matrix</a>"
   ],
   "!Commits": [


### PR DESCRIPTION
This ensures we link directly to the options we're offering as per https://github.com/whatwg/spec-factory/pull/53.