### PR TITLE
Quote attributes including macros for WHATWG

### DIFF
--- a/boilerplate/whatwg/computed-metadata-LS-COMMIT.include
+++ b/boilerplate/whatwg/computed-metadata-LS-COMMIT.include
@@ -2,15 +2,15 @@
   "Title": "[SPECTITLE] Standard Commit [COMMIT-SHA] Snapshot",
   "Logo": "https://resources.whatwg.org/logo-[SHORTNAME]-snapshot.svg",
   "!Participate": [
-    "<a href=https://github.com/whatwg/[SHORTNAME]>GitHub whatwg/[SHORTNAME]</a> (<a href=https://github.com/whatwg/[SHORTNAME]/issues/new/choose>new issue</a>, <a href=https://github.com/whatwg/[SHORTNAME]/issues>open issues</a>)",
+    "<a href=\"https://github.com/whatwg/[SHORTNAME]\">GitHub whatwg/[SHORTNAME]</a> (<a href=\"https://github.com/whatwg/[SHORTNAME]/issues/new/choose\">new issue</a>, <a href=\"https://github.com/whatwg/[SHORTNAME]/issues\">open issues</a>)",
     "<a href=https://whatwg.org/chat>Chat on Matrix</a>"
   ],
   "!Commits": [
-    "<a href=https://github.com/whatwg/[SHORTNAME]/commits>GitHub whatwg/[SHORTNAME]/commits</a>",
-    "<a href=https://[SHORTNAME].spec.whatwg.org/ id=commit-snapshot-link>Go to the living standard</a>",
-    "<a href=https://twitter.com/[TWITTER]>@[TWITTER]</a>"
+    "<a href=\"https://github.com/whatwg/[SHORTNAME]/commits\">GitHub whatwg/[SHORTNAME]/commits</a>",
+    "<a href=\"https://[SHORTNAME].spec.whatwg.org/\" id=commit-snapshot-link>Go to the living standard</a>",
+    "<a href=\"https://twitter.com/[TWITTER]\">@[TWITTER]</a>"
   ],
-  "!Tests": "<a href=https://github.com/web-platform-tests/wpt/tree/master/[SHORTNAME]>web-platform-tests [SHORTNAME]/</a> (<a href=https://github.com/web-platform-tests/wpt/labels/[SHORTNAME]>ongoing work</a>)",
+  "!Tests": "<a href=\"https://github.com/web-platform-tests/wpt/tree/master/[SHORTNAME]\">web-platform-tests [SHORTNAME]/</a> (<a href=\"https://github.com/web-platform-tests/wpt/labels/[SHORTNAME]\">ongoing work</a>)",
   "Warning": "obsolete",
-  "Text Macro": "H1 [SPECTITLE] <small>(<a href=https://github.com/whatwg/[SHORTNAME]/commit/[COMMIT-SHA]>Commit [COMMIT-SHA]</a>)</small>"
+  "Text Macro": "H1 [SPECTITLE] <small>(<a href=\"https://github.com/whatwg/[SHORTNAME]/commit/[COMMIT-SHA]\">Commit [COMMIT-SHA]</a>)</small>"
 }

--- a/boilerplate/whatwg/computed-metadata-LS-PR.include
+++ b/boilerplate/whatwg/computed-metadata-LS-PR.include
@@ -2,15 +2,15 @@
   "Title": "[SPECTITLE] Standard Pull Request #[PR-NUMBER] Preview",
   "Logo": "https://resources.whatwg.org/logo-[SHORTNAME]-snapshot.svg",
   "!Participate": [
-    "<a href=https://github.com/whatwg/[SHORTNAME]>GitHub whatwg/[SHORTNAME]</a> (<a href=https://github.com/whatwg/[SHORTNAME]/issues/new/choose>new issue</a>, <a href=https://github.com/whatwg/[SHORTNAME]/issues>open issues</a>)",
+    "<a href=\"https://github.com/whatwg/[SHORTNAME]\">GitHub whatwg/[SHORTNAME]</a> (<a href=\"https://github.com/whatwg/[SHORTNAME]/issues/new/choose\">new issue</a>, <a href=\"https://github.com/whatwg/[SHORTNAME]/issues\">open issues</a>)",
     "<a href=https://whatwg.org/chat>Chat on Matrix</a>"
   ],
   "!Commits": [
-    "<a href=https://github.com/whatwg/[SHORTNAME]/commits>GitHub whatwg/[SHORTNAME]/commits</a>",
-    "<a href=https://[SHORTNAME].spec.whatwg.org/ id=commit-snapshot-link>Go to the living standard</a>",
-    "<a href=https://twitter.com/[TWITTER]>@[TWITTER]</a>"
+    "<a href=\"https://github.com/whatwg/[SHORTNAME]/commits\">GitHub whatwg/[SHORTNAME]/commits</a>",
+    "<a href=\"https://[SHORTNAME].spec.whatwg.org/\" id=commit-snapshot-link>Go to the living standard</a>",
+    "<a href=\"https://twitter.com/[TWITTER]\">@[TWITTER]</a>"
   ],
-  "!Tests": "<a href=https://github.com/web-platform-tests/wpt/tree/master/[SHORTNAME]>web-platform-tests [SHORTNAME]/</a> (<a href=https://github.com/web-platform-tests/wpt/labels/[SHORTNAME]>ongoing work</a>)",
+  "!Tests": "<a href=\"https://github.com/web-platform-tests/wpt/tree/master/[SHORTNAME]\">web-platform-tests [SHORTNAME]/</a> (<a href=\"https://github.com/web-platform-tests/wpt/labels/[SHORTNAME]\">ongoing work</a>)",
   "Warning": "custom",
-  "Text Macro": "H1 [SPECTITLE] <small>(<a href=https://github.com/whatwg/[SHORTNAME]/pull/[PR-NUMBER]>PR #[PR-NUMBER]</a>)</small>"
+  "Text Macro": "H1 [SPECTITLE] <small>(<a href=\"https://github.com/whatwg/[SHORTNAME]/pull/[PR-NUMBER]\">PR #[PR-NUMBER]</a>)</small>"
 }

--- a/boilerplate/whatwg/computed-metadata.include
+++ b/boilerplate/whatwg/computed-metadata.include
@@ -2,14 +2,14 @@
   "Title": "[SPECTITLE] Standard",
   "Logo": "https://resources.whatwg.org/logo-[SHORTNAME].svg",
   "!Participate": [
-    "<a href=https://github.com/whatwg/[SHORTNAME]>GitHub whatwg/[SHORTNAME]</a> (<a href=https://github.com/whatwg/[SHORTNAME]/issues/new/choose>new issue</a>, <a href=https://github.com/whatwg/[SHORTNAME]/issues>open issues</a>)",
+    "<a href=\"https://github.com/whatwg/[SHORTNAME]\">GitHub whatwg/[SHORTNAME]</a> (<a href=\"https://github.com/whatwg/[SHORTNAME]/issues/new/choose\">new issue</a>, <a href=\"https://github.com/whatwg/[SHORTNAME]/issues\">open issues</a>)",
     "<a href=https://whatwg.org/chat>Chat on Matrix</a>"
   ],
   "!Commits": [
-    "<a href=https://github.com/whatwg/[SHORTNAME]/commits>GitHub whatwg/[SHORTNAME]/commits</a>",
-    "<a href=/commit-snapshots/[COMMIT-SHA]/ id=commit-snapshot-link>Snapshot as of this commit</a>",
-    "<a href=https://twitter.com/[TWITTER]>@[TWITTER]</a>"
+    "<a href=\"https://github.com/whatwg/[SHORTNAME]/commits\">GitHub whatwg/[SHORTNAME]/commits</a>",
+    "<a href=\"/commit-snapshots/[COMMIT-SHA]/\" id=commit-snapshot-link>Snapshot as of this commit</a>",
+    "<a href=\"https://twitter.com/[TWITTER]\">@[TWITTER]</a>"
   ],
-  "!Tests": "<a href=https://github.com/web-platform-tests/wpt/tree/master/[SHORTNAME]>web-platform-tests [SHORTNAME]/</a> (<a href=https://github.com/web-platform-tests/wpt/labels/[SHORTNAME]>ongoing work</a>)",
+  "!Tests": "<a href=\"https://github.com/web-platform-tests/wpt/tree/master/[SHORTNAME]\">web-platform-tests [SHORTNAME]/</a> (<a href=\"https://github.com/web-platform-tests/wpt/labels/[SHORTNAME]\">ongoing work</a>)",
   "Text Macro": "H1 [SPECTITLE]"
 }


### PR DESCRIPTION
In particular, if you use `make local` for WebIDL, which passes `--md-Text-Macro="COMMIT-SHA LOCAL COPY"`, it expands to
```html
<a href=/commit-snapshots/LOCAL COPY/ id=commit-snapshot-link>Snapshot as of this commit</a>
```
Note that the `href` attribute ends early. This leads to the inscrutable
```
LINE 1:1: Spurious / in <a>.
```