### PR TITLE
Avoid bare ampersands in WebAssembly URLs

### DIFF
--- a/boilerplate/wasm/status-ED.include
+++ b/boilerplate/wasm/status-ED.include
@@ -8,7 +8,7 @@
   <a href="https://github.com/WebAssembly/spec/issues">GitHub Issues</a>
   are preferred for discussion of this specification.
   All issues and comments are
-  <a href="https://github.com/WebAssembly/spec/issues?utf8=%E2%9C%93&q=is%3Aissue++">archived</a>.
+  <a href="https://github.com/WebAssembly/spec/issues?utf8=%E2%9C%93&amp;q=is%3Aissue++">archived</a>.
 </p>
 <p>
   This document was produced by the

--- a/boilerplate/wasm/status-FPWD.include
+++ b/boilerplate/wasm/status-FPWD.include
@@ -16,7 +16,7 @@
     <a href="https://github.com/WebAssembly/spec/issues">GitHub Issues</a>
     are preferred for discussion of this specification.
     All issues and comments are
-    <a href="https://github.com/WebAssembly/spec/issues?utf8=%E2%9C%93&q=is%3Aissue++">archived</a>.
+    <a href="https://github.com/WebAssembly/spec/issues?utf8=%E2%9C%93&amp;q=is%3Aissue++">archived</a>.
   </p>
   <p>
     This document was produced by the

--- a/boilerplate/wasm/status-WD.include
+++ b/boilerplate/wasm/status-WD.include
@@ -16,7 +16,7 @@
     <a href="https://github.com/WebAssembly/spec/issues">GitHub Issues</a>
     are preferred for discussion of this specification.
     All issues and comments are
-    <a href="https://github.com/WebAssembly/spec/issues?utf8=%E2%9C%93&q=is%3Aissue++">archived</a>.
+    <a href="https://github.com/WebAssembly/spec/issues?utf8=%E2%9C%93&amp;q=is%3Aissue++">archived</a>.
   </p>
   <p>
     This document was produced by the


### PR DESCRIPTION
This causes
```
LINE 11:69: Character reference '&q' didn't end in ;.
```