### PR TITLE
Add boilerplate for the HTML-WG

### DIFF
--- a/boilerplate/htmlwg/copyright.include
+++ b/boilerplate/htmlwg/copyright.include
@@ -1,0 +1,2 @@
+<a href="https://www.w3.org/policies/#copyright">Copyright</a> © [YEAR] <a href="https://www.w3.org/">World Wide Web Consortium</a> and WHATWG (Apple, Google, Mozilla, Microsoft). <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/policies/#Legal_Disclaimer">liability</a>, and <a href="https://www.w3.org/policies/#W3C_Trademarks">trademark</a> rules apply. This work is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License.</a>
+

--- a/boilerplate/htmlwg/status.include
+++ b/boilerplate/htmlwg/status.include
@@ -1,0 +1,119 @@
+<p exclude-if="ED,UD"><em>This section describes the status of this document at the time of its publication.
+	A list of current W3C publications
+	and the latest revision of this technical report
+	can be found in the <a href="https://www.w3.org/TR/">W3C technical reports index at https://www.w3.org/TR/.</a></em>
+
+<p include-if="UD">
+	This document an early unofficial draft.
+	It is intended to become a deliverable of the <a href="https://www.w3.org/groups/wg/htmlwg/">W3C HTML Working Group</a>,
+	but has not yet been taken up by that Working Group.
+	It is provided for discussion only and may change at any moment.
+	Its publication here does not imply endorsement of its contents by W3C.
+	Don’t cite this document other than as work in progress.
+
+<p include-if="ED">
+	This is a public copy of the editors’ draft.
+	It is provided for discussion only and may change at any moment.
+	Its publication here does not imply endorsement of its contents by W3C.
+	Don’t cite this document other than as work in progress.
+
+<p include-if="REC">
+	This document was published
+	by the <a href="https://www.w3.org/groups/htmlwg/css">HTML Working Group</a>
+	as a [LONGSTATUS] using the <a
+	href='https://www.w3.org/2023/Process-20231103/#recs-and-notes'>Recommendation
+	track</a>.
+	A W3C Recommendation is a specification that, after extensive consensus-building, is endorsed by
+	<abbr title="World Wide Web Consortium">W3C</abbr> and its Members,
+	and has commitments from Working Group members to <a
+	href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> for implementations.
+
+<p include-if="PR">
+	This document was published
+	by the <a href="https://www.w3.org/groups/wg/htmlwg">HTML Working Group</a>
+	as a <strong>Proposed Recommendation</strong> using the <a
+	href='https://www.w3.org/2023/Process-20231103/#recs-and-notes'>Recommendation
+	track</a>.
+	Publication as a Proposed Recommendation
+	does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
+
+<p include-if="CR">
+	This document was published
+	by the <a href="https://www.w3.org/groups/wg/htmlwg">HTML Working Group</a>
+	as a <strong>Candidate Recommendation Snapshot</strong> using the <a
+	href='https://www.w3.org/2023/Process-20231103/#recs-and-notes'>Recommendation
+	track</a>.
+	Publication as a Candidate Recommendation
+	does not imply endorsement by
+	<abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
+	A Candidate Recommendation Snapshot has received
+	<a href="https://www.w3.org/2023/Process-20231103/#dfn-wide-review">wide review</a>,
+	is intended to gather implementation experience, and has commitments from Working Group members to <a
+	href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> for implementations.
+	This document is intended to become a W3C Recommendation;
+	it will remain a Candidate Recommendation at least until
+	<time class="status-deadline" datetime="[ISODEADLINE?]">[DEADLINE?]</time>
+	to gather additional feedback.
+
+<p include-if="CRD">
+	This document was published
+	by the <a href="https://www.w3.org/groups/wg/htmlwg">HTML Working Group</a>
+	as a <strong>Candidate Recommendation Draft</strong> using the <a
+	href='https://www.w3.org/2023/Process-20231103/#recs-and-notes'>Recommendation
+	track</a>.
+	Publication as a Candidate Recommendation
+	does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr>
+	and its Members.
+	A Candidate Recommendation Draft
+	integrates changes from the previous Candidate Recommendation
+	that the Working Group intends to include in a subsequent Candidate Recommendation Snapshot.
+
+<p include-if="WD">
+	This document was published
+	by the <a href="https://www.w3.org/groups/htmlwg/css">HTML Working Group</a>
+	as a <strong>Working Draft</strong> using the <a
+	href='https://www.w3.org/2023/Process-20231103/#recs-and-notes'>Recommendation
+	track</a>.
+	Publication as a Working Draft
+	does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
+
+<p include-if="FPWD">
+	This document was published
+	by the <a href="https://www.w3.org/groups/wg/htmlwg">HTML Working Group</a>
+	as a <strong>First Public Working Draft</strong> using the <a
+	href='https://www.w3.org/2023/Process-20231103/#recs-and-notes'>Recommendation
+	track</a>.
+	Publication as a First Public Working Draft
+	does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
+
+<p include-if="NOTE" data-deliverer="32061">
+	This document was published
+	by the <a href="https://www.w3.org/groups/wg/htmlwg">HTML Working Group</a>
+	as a Group Note
+	using the <a href="https://www.w3.org/2023/Process-20231103/#recs-and-notes">Note track</a>.
+	Group Notes are not endorsed by W3C nor its Members.
+
+<p include-if="WD, FPWD, CRD">
+	This is a draft document
+	and may be updated, replaced
+	or obsoleted by other documents at any time.
+	It is inappropriate to cite this document as other than work in progress.
+
+<p exclude-if="UD">This document is governed by the
+	<a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20231103/">03 November 2023 W3C Process Document</a>.
+
+<p exclude-if="ED,UD,NOTE">This document was produced by a group operating under the
+	<a href="https://www.w3.org/Consortium/Patent-Policy-20200915/">W3C Patent Policy</a>.
+	W3C maintains a
+	<a rel="disclosure" href="https://www.w3.org/groups/wg/css/ipr">public list of any patent disclosures</a>
+	made in connection with the deliverables of the group;
+	that page also includes instructions for disclosing a patent.
+	An individual who has actual knowledge of a patent which the individual believes
+	contains <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#def-essential">Essential Claim(s)</a>
+	must disclose the information in accordance with
+	<a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
+
+<p include-if="NOTE">The <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/">15 September 2020 W3C Patent Policy</a>
+	does not carry any licensing requirements or commitments on this document.
+
+<p>[STATUSTEXT]


### PR DESCRIPTION
This is for the [HTML WG](https://www.w3.org/groups/wg/htmlwg/), and in particular, its [Ruby](https://www.w3.org/2022/06/html-wg-charter.html#ruby) deliverable.

`status.include` inspired by that of the CSS-WG

`copyright.include` according to https://github.com/w3c/specberus/pull/1814

This is distinct from the neighboring directory of https://github.com/speced/bikeshed-boilerplate/tree/main/boilerplate/html, as despite the name of that directory, it's includes related to the <a href="https://www.w3.org/groups/wg/webplatform">Web Platform Working Group</a>