### PR TITLE
[das] updated for joint working group(s) and PP link

### DIFF
--- a/boilerplate/dap/status-CR.include
+++ b/boilerplate/dap/status-CR.include
@@ -27,7 +27,13 @@
 	If you wish to make comments regarding this document, please send them to
 	<a href="mailto:public-device-apis@w3.org?Subject=%5B[SHORTNAME]%5D%20PUT%20SUBJECT%20HERE">public-device-apis@w3.org</a>
 	(<a href="mailto:public-device-apis-request@w3.org?subject=subscribe">subscribe</a>,
-	<a href="https://lists.w3.org/Archives/Public/public-device-apis/">archives</a>).
+	<a href="https://lists.w3.org/Archives/Public/public-device-apis/">archives</a>)
+  <span include-if="Text Macro: JOINTWEBAPPS">
+    and <a href="mailto:public-webapps@w3.org?Subject=%5Borientation-event%5D%20PUT%20SUBJECT%20HERE">public-webapps@w3.org</a> 
+    (<a href="mailto:public-webapps-request@w3.org?subject=subscribe">subscribe</a>, 
+    <a href="https://lists.w3.org/Archives/Public/public-webapps/">archives</a>)
+  </span>
+  .
 	When sending e-mail,
 	please put the text “[SHORTNAME]” in the subject,
 	preferably like this:

--- a/boilerplate/dap/status-CR.include
+++ b/boilerplate/dap/status-CR.include
@@ -40,7 +40,7 @@
       <abbr title="World Wide Web Consortium">W3C</abbr> and its Members. 
       A Candidate Recommendation Snapshot has received <a 
       href="https://www.w3.org/2023/Process-20231103/#dfn-wide-review">wide review</a>, is intended to
-      gather implementation experience, and has commitments from Working Group members to <a 
+      gather implementation experience, and has commitments from Working Group(s) members to <a 
       href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> for implementations.
 </p>
 
@@ -49,7 +49,7 @@
   is to have a minimum of two independent and interoperable user agents that
   implementation all the features of this specification, which will be determined by
   passing the user agent tests defined in the test suite developed by the Working
-  Group. The Working Group will prepare an implementation report to track progress.
+  Group(s). The Working Group(s) will prepare an implementation report to track progress.
 </p>
 
 <p exclude-if="Text Macro: JOINT">
@@ -58,8 +58,8 @@
 	W3C maintains a <a href="https://www.w3.org/groups/wg/das/ipr" rel=disclosure>public list of any patent disclosures</a>
 	made in connection with the deliverables of the group;
 	that page also includes instructions for disclosing a patent.
-	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#def-essential">Essential Claim(s)</a>
-	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
+	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential Claim(s)</a>
+	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 </p>
 <p include-if="Text Macro: JOINTWEBAPPS">
   This document was produced by groups operating under

--- a/boilerplate/dap/status-CR.include
+++ b/boilerplate/dap/status-CR.include
@@ -40,16 +40,16 @@
       <abbr title="World Wide Web Consortium">W3C</abbr> and its Members. 
       A Candidate Recommendation Snapshot has received <a 
       href="https://www.w3.org/2023/Process-20231103/#dfn-wide-review">wide review</a>, is intended to
-      gather implementation experience, and has commitments from Working Group(s) members to <a 
+      gather implementation experience, and has commitments from Working Group<span include-if="Text Macro: JOINT">s</span> members to <a 
       href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> for implementations.
 </p>
 
 <p>
   The entrance criteria for this document to enter the Proposed Recommendation stage
   is to have a minimum of two independent and interoperable user agents that
-  implementation all the features of this specification, which will be determined by
+  implement all the features of this specification, which will be determined by
   passing the user agent tests defined in the test suite developed by the Working
-  Group(s). The Working Group(s) will prepare an implementation report to track progress.
+  Group<span include-if="Text Macro: JOINT">s</span>. The Working Group<span include-if="Text Macro: JOINT">s</span> will prepare an implementation report to track progress.
 </p>
 
 <p exclude-if="Text Macro: JOINT">

--- a/boilerplate/dap/status-CRD.include
+++ b/boilerplate/dap/status-CRD.include
@@ -35,7 +35,7 @@
 <p>
   Publication as a Candidate Recommendation does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr>
   and its Members. A Candidate Recommendation Draft integrates changes from the
-  previous Candidate Recommendation that the Working Group(s) intends to include in
+  previous Candidate Recommendation that the Working Group<span include-if="Text Macro: JOINT">s</span> intends to include in
   a subsequent Candidate Recommendation Snapshot. This is a draft document and
   may be updated, replaced or obsoleted by other documents at any time. It is
   inappropriate to cite this document as other than work in progress.
@@ -44,9 +44,9 @@
 <p>
   The entrance criteria for this document to enter the Proposed Recommendation stage
   is to have a minimum of two independent and interoperable user agents that
-  implementation all the features of this specification, which will be determined by
+  implement all the features of this specification, which will be determined by
   passing the user agent tests defined in the test suite developed by the Working
-  Group(s). The Working Group(s) will prepare an implementation report to track progress.
+  Group<span include-if="Text Macro: JOINT">s</span>. The Working Group<span include-if="Text Macro: JOINT">s</span> will prepare an implementation report to track progress.
 </p>
 
 <p exclude-if="Text Macro: JOINT">

--- a/boilerplate/dap/status-CRD.include
+++ b/boilerplate/dap/status-CRD.include
@@ -35,7 +35,7 @@
 <p>
   Publication as a Candidate Recommendation does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr>
   and its Members. A Candidate Recommendation Draft integrates changes from the
-  previous Candidate Recommendation that the Working Group<span include-if="Text Macro: JOINT">s</span> intends to include in
+  previous Candidate Recommendation that the Working Group<span include-if="Text Macro: JOINT">s</span> intend<span exclude-if="Text Macro: JOINT">s</span> to include in
   a subsequent Candidate Recommendation Snapshot. This is a draft document and
   may be updated, replaced or obsoleted by other documents at any time. It is
   inappropriate to cite this document as other than work in progress.

--- a/boilerplate/dap/status-CRD.include
+++ b/boilerplate/dap/status-CRD.include
@@ -35,7 +35,7 @@
 <p>
   Publication as a Candidate Recommendation does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr>
   and its Members. A Candidate Recommendation Draft integrates changes from the
-  previous Candidate Recommendation that the Working Group intends to include in
+  previous Candidate Recommendation that the Working Group(s) intends to include in
   a subsequent Candidate Recommendation Snapshot. This is a draft document and
   may be updated, replaced or obsoleted by other documents at any time. It is
   inappropriate to cite this document as other than work in progress.
@@ -46,7 +46,7 @@
   is to have a minimum of two independent and interoperable user agents that
   implementation all the features of this specification, which will be determined by
   passing the user agent tests defined in the test suite developed by the Working
-  Group. The Working Group will prepare an implementation report to track progress.
+  Group(s). The Working Group(s) will prepare an implementation report to track progress.
 </p>
 
 <p exclude-if="Text Macro: JOINT">
@@ -55,8 +55,8 @@
 	W3C maintains a <a href="https://www.w3.org/groups/wg/das/ipr" rel=disclosure>public list of any patent disclosures</a>
 	made in connection with the deliverables of the group;
 	that page also includes instructions for disclosing a patent.
-	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#def-essential">Essential Claim(s)</a>
-	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
+	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential Claim(s)</a>
+	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 </p>
 <p include-if="Text Macro: JOINTWEBAPPS">
   This document was produced by groups operating under

--- a/boilerplate/dap/status-CRD.include
+++ b/boilerplate/dap/status-CRD.include
@@ -24,7 +24,13 @@
 	If you wish to make comments regarding this document, please send them to
 	<a href="mailto:public-device-apis@w3.org?Subject=%5B[SHORTNAME]%5D%20PUT%20SUBJECT%20HERE">public-device-apis@w3.org</a>
 	(<a href="mailto:public-device-apis-request@w3.org?subject=subscribe">subscribe</a>,
-	<a href="https://lists.w3.org/Archives/Public/public-device-apis/">archives</a>).
+	<a href="https://lists.w3.org/Archives/Public/public-device-apis/">archives</a>)
+  <span include-if="Text Macro: JOINTWEBAPPS">
+    and <a href="mailto:public-webapps@w3.org?Subject=%5Borientation-event%5D%20PUT%20SUBJECT%20HERE">public-webapps@w3.org</a> 
+    (<a href="mailto:public-webapps-request@w3.org?subject=subscribe">subscribe</a>, 
+    <a href="https://lists.w3.org/Archives/Public/public-webapps/">archives</a>)
+  </span>
+	.
 	When sending e-mail,
 	please put the text “[SHORTNAME]” in the subject,
 	preferably like this:

--- a/boilerplate/dap/status-ED.include
+++ b/boilerplate/dap/status-ED.include
@@ -17,9 +17,13 @@
 	All comments are welcome.
 </p>
 
-<p>
-	This document was produced by the
+<p exclude-if="Text Macro: JOINT">
+  This document was published by the
   <a href="https://www.w3.org/groups/wg/das">Devices and Sensors Working Group</a>.
+</p>
+<p include-if="Text Macro: JOINTWEBAPPS">
+  This document was published by the <a href="https://www.w3.org/groups/wg/das">Devices and Sensors Working Group</a> and
+	the <a href="https://www.w3.org/groups/wg/webapps">Web Applications Working Group</a>.
 </p>
 
 <p exclude-if="Text Macro: JOINT">
@@ -28,8 +32,8 @@
 	W3C maintains a <a href="https://www.w3.org/groups/wg/das/ipr" rel=disclosure>public list of any patent disclosures</a>
 	made in connection with the deliverables of the group;
 	that page also includes instructions for disclosing a patent.
-	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#def-essential">Essential Claim(s)</a>
-	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
+	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential Claim(s)</a>
+	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 </p>
 <p include-if="Text Macro: JOINTWEBAPPS">
   This document was produced by groups operating under

--- a/boilerplate/dap/status-ED.include
+++ b/boilerplate/dap/status-ED.include
@@ -9,7 +9,13 @@
 	If you wish to make comments regarding this document, please send them to
 	<a href="mailto:public-device-apis@w3.org?Subject=%5B[SHORTNAME]%5D%20PUT%20SUBJECT%20HERE">public-device-apis@w3.org</a>
 	(<a href="mailto:public-device-apis-request@w3.org?subject=subscribe">subscribe</a>,
-	<a href="https://lists.w3.org/Archives/Public/public-device-apis/">archives</a>).
+	<a href="https://lists.w3.org/Archives/Public/public-device-apis/">archives</a>)
+  <span include-if="Text Macro: JOINTWEBAPPS">
+    and <a href="mailto:public-webapps@w3.org?Subject=%5Borientation-event%5D%20PUT%20SUBJECT%20HERE">public-webapps@w3.org</a> 
+    (<a href="mailto:public-webapps-request@w3.org?subject=subscribe">subscribe</a>, 
+    <a href="https://lists.w3.org/Archives/Public/public-webapps/">archives</a>)
+  </span>
+	.
 	When sending e-mail,
 	please put the text “[SHORTNAME]” in the subject,
 	preferably like this:

--- a/boilerplate/dap/status-FPWD.include
+++ b/boilerplate/dap/status-FPWD.include
@@ -24,7 +24,13 @@
 	If you wish to make comments regarding this document, please send them to
 	<a href="mailto:public-device-apis@w3.org?Subject=%5B[SHORTNAME]%5D%20PUT%20SUBJECT%20HERE">public-device-apis@w3.org</a>
 	(<a href="mailto:public-device-apis-request@w3.org?subject=subscribe">subscribe</a>,
-	<a href="https://lists.w3.org/Archives/Public/public-device-apis/">archives</a>).
+	<a href="https://lists.w3.org/Archives/Public/public-device-apis/">archives</a>)
+  <span include-if="Text Macro: JOINTWEBAPPS">
+    and <a href="mailto:public-webapps@w3.org?Subject=%5Borientation-event%5D%20PUT%20SUBJECT%20HERE">public-webapps@w3.org</a> 
+    (<a href="mailto:public-webapps-request@w3.org?subject=subscribe">subscribe</a>, 
+    <a href="https://lists.w3.org/Archives/Public/public-webapps/">archives</a>)
+  </span>
+	.
 	When sending e-mail,
 	please put the text “[SHORTNAME]” in the subject,
 	preferably like this:

--- a/boilerplate/dap/status-FPWD.include
+++ b/boilerplate/dap/status-FPWD.include
@@ -49,8 +49,8 @@
 	W3C maintains a <a href="https://www.w3.org/groups/wg/das/ipr" rel=disclosure>public list of any patent disclosures</a>
 	made in connection with the deliverables of the group;
 	that page also includes instructions for disclosing a patent.
-	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#def-essential">Essential Claim(s)</a>
-	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
+	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential Claim(s)</a>
+	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 </p>
 <p include-if="Text Macro: JOINTWEBAPPS">
   This document was produced by groups operating under

--- a/boilerplate/dap/status-NOTE.include
+++ b/boilerplate/dap/status-NOTE.include
@@ -17,7 +17,13 @@
 	If you wish to make comments regarding this document, please send them to
 	<a href="mailto:public-device-apis@w3.org?Subject=%5B[SHORTNAME]%5D%20PUT%20SUBJECT%20HERE">public-device-apis@w3.org</a>
 	(<a href="mailto:public-device-apis-request@w3.org?subject=subscribe">subscribe</a>,
-	<a href="https://lists.w3.org/Archives/Public/public-device-apis/">archives</a>).
+	<a href="https://lists.w3.org/Archives/Public/public-device-apis/">archives</a>)
+  <span include-if="Text Macro: JOINTWEBAPPS">
+    and <a href="mailto:public-webapps@w3.org?Subject=%5Borientation-event%5D%20PUT%20SUBJECT%20HERE">public-webapps@w3.org</a> 
+    (<a href="mailto:public-webapps-request@w3.org?subject=subscribe">subscribe</a>, 
+    <a href="https://lists.w3.org/Archives/Public/public-webapps/">archives</a>)
+  </span>
+	.
 	When sending e-mail,
 	please put the text “[SHORTNAME]” in the subject,
 	preferably like this:

--- a/boilerplate/dap/status-WD.include
+++ b/boilerplate/dap/status-WD.include
@@ -45,8 +45,8 @@
 	W3C maintains a <a href="https://www.w3.org/groups/wg/das/ipr" rel=disclosure>public list of any patent disclosures</a>
 	made in connection with the deliverables of the group;
 	that page also includes instructions for disclosing a patent.
-	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#def-essential">Essential Claim(s)</a>
-	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
+	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential Claim(s)</a>
+	must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
 </p>
 <p include-if="Text Macro: JOINTWEBAPPS">
   This document was produced by groups operating under

--- a/boilerplate/dap/status-WD.include
+++ b/boilerplate/dap/status-WD.include
@@ -24,7 +24,13 @@
 	If you wish to make comments regarding this document, please send them to
 	<a href="mailto:public-device-apis@w3.org?Subject=%5B[SHORTNAME]%5D%20PUT%20SUBJECT%20HERE">public-device-apis@w3.org</a>
 	(<a href="mailto:public-device-apis-request@w3.org?subject=subscribe">subscribe</a>,
-	<a href="https://lists.w3.org/Archives/Public/public-device-apis/">archives</a>).
+	<a href="https://lists.w3.org/Archives/Public/public-device-apis/">archives</a>)
+  <span include-if="Text Macro: JOINTWEBAPPS">
+    and <a href="mailto:public-webapps@w3.org?Subject=%5Borientation-event%5D%20PUT%20SUBJECT%20HERE">public-webapps@w3.org</a> 
+    (<a href="mailto:public-webapps-request@w3.org?subject=subscribe">subscribe</a>, 
+    <a href="https://lists.w3.org/Archives/Public/public-webapps/">archives</a>)
+  </span>
+	.
 	When sending e-mail,
 	please put the text “[SHORTNAME]” in the subject,
 	preferably like this:


### PR DESCRIPTION
put review comments to https://github.com/w3c/deviceorientation/issues/145

This is in WIP, please do not merge this now.

- replaced 'Working Group' to 'Working Group(s)'
- fixed dated PP link to non-dated one
- fixed missing joint deliverable configuration in ED