### PR TITLE
Fix patent policy boilerplate in the webfontswg boilerplate includes.

### DIFF
--- a/boilerplate/webfontswg/status-ED.include
+++ b/boilerplate/webfontswg/status-ED.include
@@ -14,7 +14,7 @@
 </p>
 
 <p>
-  This document was produced by groups operating under
+  This document was produced by a group operating under
   the <a href="https://www.w3.org/policies/patent-policy/20200915/">W3C Patent Policy</a>.
   W3C maintains a <a href="https://www.w3.org/groups/wg/webfonts/ipr" rel="disclosure">public list of any patent disclosures</a>
   made in connection with the deliverables of the group;

--- a/boilerplate/webfontswg/status-FPWD.include
+++ b/boilerplate/webfontswg/status-FPWD.include
@@ -29,7 +29,7 @@
 </p>
 
 <p>
-  This document was produced by groups operating under
+  This document was produced by a group operating under
   the <a href="https://www.w3.org/policies/patent-policy/20200915/">W3C Patent Policy</a>.
   W3C maintains a <a href="https://www.w3.org/groups/wg/webfonts/ipr" rel="disclosure">public list of any patent disclosures</a>
   made in connection with the deliverables of the group;

--- a/boilerplate/webfontswg/status-WD.include
+++ b/boilerplate/webfontswg/status-WD.include
@@ -25,7 +25,7 @@
 </p>
 
 <p>
-  This document was produced by groups operating under
+  This document was produced by a group operating under
   the <a href="https://www.w3.org/policies/patent-policy/20200915/">W3C Patent Policy</a>.
   W3C maintains a <a href="https://www.w3.org/groups/wg/webfonts/ipr" rel="disclosure">public list of any patent disclosures</a>
   made in connection with the deliverables of the group;


### PR DESCRIPTION
s/by groups/a group/ to conform with w3c pubrules.