### PR TITLE
Create header.include

### DIFF
--- a/boilerplate/w3t/header.include
+++ b/boilerplate/w3t/header.include
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <title>[TITLE]</title>
+  <meta name="w3c-status" content="[STATUS]">
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet>
+</head>
+<body class="h-entry">
+<div class="head">
+  <p data-fill-with="logo"></p>
+  <h1 id="title" class="p-name no-ref">[TITLE]</h1>
+  <p id='w3c-state'><time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
+  <details open>
+    <summary>More details about this document</summary>
+    <div data-fill-with="spec-metadata"></div>
+  </details>
+  <div data-fill-with="warning"></div>
+  <p class='copyright' data-fill-with='copyright'></p>
+  <hr title="Separator for header">
+</div>
+
+<div class="p-summary" data-fill-with="abstract"></div>
+
+<h2 class='no-num no-toc no-ref' id='sotd'>Status of this document</h2>
+<div data-fill-with="status"></div>
+<div data-fill-with="at-risk"></div>
+
+<nav data-fill-with="table-of-contents" id="toc"></nav>
+<main>


### PR DESCRIPTION
A small modification to the W3C's header.include to be able to create Team Reports with bikeshed, such as:

https://w3c.github.io/identity-web-impact/
https://w3c.github.io/ai-web-impact/