### PR TITLE
"Implementation Report" no longer required at CR steps

### DIFF
--- a/boilerplate/doctypes.kdl
+++ b/boilerplate/doctypes.kdl
@@ -186,11 +186,11 @@ org "w3c" {
         group-types "wg"
     }
     status "CR" "W3C Candidate Recommendation Snapshot" {
-        requires "Level" "ED" "TR" "Issue Tracking" "Date" "Implementation Report"
+        requires "Level" "ED" "TR" "Issue Tracking" "Date"
         group-types "wg"
     }
     status "CRD" "W3C Candidate Recommendation Draft" {
-        requires "Level" "ED" "TR" "Issue Tracking" "Date" "Implementation Report" "Deadline"
+        requires "Level" "ED" "TR" "Issue Tracking" "Date" "Deadline"
         group-types "wg"
     }
     status "PR" "W3C Proposed Recommendation" {


### PR DESCRIPTION
While it remains good practice to have a preliminary implementation report when a spec moves to Candidate Recommendation, "a statement that no such report exists" is ok from a publication rules perspective: https://www.w3.org/pubrules/doc/rules/?profile=CR#implReport

Bikeshed required a link to an implementation report at CR phases. This update drops the requirement to cater for specs (such as WebGPU) that make a statement in the Status of this Document section.