### PR TITLE
Limit Findings and Draft Findings to the TAG.

### DIFF
--- a/boilerplate/doctypes.kdl
+++ b/boilerplate/doctypes.kdl
@@ -68,8 +68,6 @@ status "LS-COMMIT" "Commit Snapshot"
 status "LS-BRANCH" "Branch Snapshot"
 status "LS-PR" "PR Preview"
 status "LD" "Living Document"
-status "DRAFT-FINDING" "Draft Finding"
-status "FINDING" "Finding"
 
 org "whatwg" {
     group "whatwg" priv-sec=false
@@ -264,11 +262,11 @@ org "w3c" {
     }
     status "DRAFT-FINDING" "Draft Finding" {
         requires "ED"
-        group-types "wg" "tag"
+        group-types "tag"
     }
     status "FINDING" "Finding" {
         requires "TR"
-        group-types "wg" "tag"
+        group-types "tag"
     }
 }
 


### PR DESCRIPTION
Other W3C groups should use Notes, which are defined in the Process.
Non-W3C groups can use Dream or an appropriate status from their org.


This depends on https://github.com/speced/bikeshed/pull/2998 to update the documentation, so I won't merge this until that's merged.