### PR TITLE
Fix Candidate Recommendation Draft metadata checks

### DIFF
--- a/boilerplate/doctypes.kdl
+++ b/boilerplate/doctypes.kdl
@@ -191,7 +191,7 @@ org "w3c" {
         group-types "wg"
     }
     status "CRD" "W3C Candidate Recommendation Draft" {
-        requires "Level" "ED" "TR" "Issue Tracking" "Date" "Deadline"
+        requires "Level" "ED" "TR" "Issue Tracking" "Date"
         group-types "wg"
     }
     status "PR" "W3C Proposed Recommendation" {

--- a/boilerplate/doctypes.kdl
+++ b/boilerplate/doctypes.kdl
@@ -187,7 +187,7 @@ org "w3c" {
         group-types "wg"
     }
     status "CR" "W3C Candidate Recommendation Snapshot" {
-        requires "Level" "ED" "TR" "Issue Tracking" "Date"
+        requires "Level" "ED" "TR" "Issue Tracking" "Date" "Deadline"
         group-types "wg"
     }
     status "CRD" "W3C Candidate Recommendation Draft" {


### PR DESCRIPTION
CRD does not require this deadline information per process: https://www.w3.org/policies/process/#publishing-crud

Without this fix CRD builds without "Deadline" metadata will fail.

Fix https://github.com/speced/bikeshed/issues/3031