### PR TITLE
Fix typo in doctypes.kdl

### DIFF
--- a/boilerplate/doctypes.kdl
+++ b/boilerplate/doctypes.kdl
@@ -96,7 +96,7 @@ org "w3c" {
     use `type=null`.
     */
 
-    group "ab" type=ab
+    group "ab" type="ab"
     group "act-framework" type="wg"
     group "act-rules-format" type="wg"
     group "audiocg" type="cg"


### PR DESCRIPTION
Looks like this typo breaks the parsing, see: https://github.com/w3c/webdriver-bidi/actions/runs/13390041546/job/37395500011?pr=876