### PR TITLE
fix typos in webapps and webediting

### DIFF
--- a/boilerplate/webapps/status.include
+++ b/boilerplate/webapps/status.include
@@ -75,7 +75,7 @@
 	Publication as a First Public Working Draft
 	does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
 
-<p include-if="NOTE"
+<p include-if="NOTE">
 	This document was published
 	by the <a href="https://www.w3.org/groups/wg/webapps">Web Applications Working Group</a>
 	as a Group Note

--- a/boilerplate/webediting/status.include
+++ b/boilerplate/webediting/status.include
@@ -75,7 +75,7 @@
 	Publication as a First Public Working Draft
 	does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
 
-<p include-if="NOTE"
+<p include-if="NOTE">
 	This document was published
 	by the <a href="https://www.w3.org/groups/wg/webediting">Web Editing Working Group</a>
 	as a Group Note


### PR DESCRIPTION
reported by https://github.com/w3c/ServiceWorker/actions/runs/13695765623/job/38366486433#step:3:847.