### PR TITLE
remove extra whitespace from TAG boilerplates

### DIFF
--- a/boilerplate/tag/status-NOTE-ED.include
+++ b/boilerplate/tag/status-NOTE-ED.include
@@ -4,8 +4,7 @@
     <abbr title="World Wide Web Consortium">W3C</abbr> publications and the
     latest revision of this technical report can be found in the <a
     href="https://www.w3.org/TR/"><abbr title="World Wide Web
-    Consortium">W3C</abbr> standards and drafts index</a>
-   .</em>
+    Consortium">W3C</abbr> standards and drafts index</a>.</em>
   </p>
 
   <p>

--- a/boilerplate/tag/status-NOTE-WD.include
+++ b/boilerplate/tag/status-NOTE-WD.include
@@ -4,8 +4,7 @@
     <abbr title="World Wide Web Consortium">W3C</abbr> publications and the
     latest revision of this technical report can be found in the <a
     href="https://www.w3.org/TR/"><abbr title="World Wide Web
-    Consortium">W3C</abbr> standards and drafts index</a>
-   .</em>
+    Consortium">W3C</abbr> standards and drafts index</a>.</em>
   </p>
 
   <p>

--- a/boilerplate/tag/status-NOTE.include
+++ b/boilerplate/tag/status-NOTE.include
@@ -4,8 +4,7 @@
     <abbr title="World Wide Web Consortium">W3C</abbr> publications and the
     latest revision of this technical report can be found in the <a
     href="https://www.w3.org/TR/"><abbr title="World Wide Web
-    Consortium">W3C</abbr> standards and drafts index</a>
-   .</em>
+    Consortium">W3C</abbr> standards and drafts index</a>.</em>
   </p>
 
   <p>


### PR DESCRIPTION
https://github.com/speced/bikeshed-boilerplate/pull/158 removed some texts but this introduced an extra whitespace in the TR intro.