### PR TITLE
[GPU for the Web WG] Drop mention of "wide review" in CRD boilerplate

### DIFF
--- a/boilerplate/gpuwg/status.include
+++ b/boilerplate/gpuwg/status.include
@@ -26,7 +26,7 @@
 </p>
 
 <p include-if="CRD">
-  This document was published by the <a href="https://www.w3.org/groups/wg/gpu/">GPU for the Web Working Group</a> as a Candidate Recommendation Draft using the <a href="https://www.w3.org/policies/process/20231103/#recs-and-notes">Recommendation track</a>. This document will remain a Candidate Recommendation at least until <time class="status-deadline" datetime="[ISODEADLINE?]">[DEADLINE?]</time> in order to ensure the opportunity for wide review.
+  This document was published by the <a href="https://www.w3.org/groups/wg/gpu/">GPU for the Web Working Group</a> as a Candidate Recommendation Draft using the <a href="https://www.w3.org/policies/process/20231103/#recs-and-notes">Recommendation track</a>. This document will remain a Candidate Recommendation at least until <time class="status-deadline" datetime="[ISODEADLINE?]">[DEADLINE?]</time>.
 </p>
 
 <p include-if="CR">


### PR DESCRIPTION
Tools react on the presence of "wide review" in the Status of This Documentation section to send notifications to the wide review list. That's good for Candidate Recommendation Snapshots, but creates noise for Candidate Recommendation Drafts.