### PR TITLE
Remove style-var-click-highlighting from WHATWG specs

### DIFF
--- a/boilerplate/whatwg/defaults.include
+++ b/boilerplate/whatwg/defaults.include
@@ -6,7 +6,7 @@
   "Die On": "lint",
   "Status": "LS",
   "No Editor": "yes",
-  "Boilerplate": "style-md-lists off, style-autolinks off, style-selflinks off, style-counters off, style-syntax-highlighting off, style-idl-highlighting off, style-colors off, style-issues off, feedback-header off, conformance off, issues-index off",
+  "Boilerplate": "style-md-lists off, style-autolinks off, style-selflinks off, style-counters off, style-syntax-highlighting off, style-idl-highlighting off, style-colors off, style-issues off, style-var-click-highlighting off, feedback-header off, conformance off, issues-index off",
   "Dark Mode": "on",
   "Include Mdn Panels": "if possible",
   "Complain About": "missing-example-ids yes, accidental-2119 yes",


### PR DESCRIPTION
It is now included in the shared, cached stylesheet as of https://github.com/whatwg/whatwg.org/pull/470.

/cc @jmdyck.

I think I have permissions to merge this but I feel bad doing so without code review, so maybe @annevk?