### PR TITLE
Add w3c/fdpcg group to doctypes.kdl

### DIFF
--- a/boilerplate/doctypes.kdl
+++ b/boilerplate/doctypes.kdl
@@ -109,6 +109,7 @@ org "w3c" {
         requires "Work Status"
     }
     group "dap" type="wg" priv-sec=true
+    group "fdpcg" type="cg"
     group "fedid" type="wg" priv-sec=true
     group "fedidcg" type="cg"
     group "fxtf" type="wg" priv-sec=true


### PR DESCRIPTION
Register the W3C [FAIR Data Point Community Group].

[FAIR Data Point Community Group]: https://www.w3.org/community/fdp/