### PR TITLE
Fix dap boilerplate: move [STATUSTEXT] outside <p> wrapper

### DIFF
--- a/boilerplate/dap/status-CR.include
+++ b/boilerplate/dap/status-CR.include
@@ -88,7 +88,5 @@
 </p>
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/policies/process/20250818/">18 August 2025 W3C Process Document</a>.
-
-<p>
-	[STATUSTEXT]
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/policies/process/20250818/">18 August 2025 W3C Process Document</a>.</p>
+[STATUSTEXT]

--- a/boilerplate/dap/status-CRD.include
+++ b/boilerplate/dap/status-CRD.include
@@ -85,7 +85,5 @@
 </p>
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/policies/process/20250818/">18 August 2025 W3C Process Document</a>.
-
-<p>
-	[STATUSTEXT]
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/policies/process/20250818/">18 August 2025 W3C Process Document</a>.</p>
+[STATUSTEXT]

--- a/boilerplate/dap/status-DISC.include
+++ b/boilerplate/dap/status-DISC.include
@@ -59,5 +59,5 @@
   This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/policies/process/20250818/">18 August 2025 W3C Process Document</a>.
 </p>
 
-<p>
-	[STATUSTEXT]
+
+[STATUSTEXT]

--- a/boilerplate/dap/status-ED.include
+++ b/boilerplate/dap/status-ED.include
@@ -65,5 +65,5 @@
   This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/policies/process/20250818/">18 August 2025 W3C Process Document</a>.
 </p>
 
-<p>
-	[STATUSTEXT]
+
+[STATUSTEXT]

--- a/boilerplate/dap/status-FPWD.include
+++ b/boilerplate/dap/status-FPWD.include
@@ -79,7 +79,5 @@
 </p>
 
 <p>
-  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/policies/process/20250818/">18 August 2025 W3C Process Document</a>.
-
-<p>
-	[STATUSTEXT]
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/policies/process/20250818/">18 August 2025 W3C Process Document</a>.</p>
+[STATUSTEXT]

--- a/boilerplate/dap/status-NOTE.include
+++ b/boilerplate/dap/status-NOTE.include
@@ -52,5 +52,5 @@
   This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/policies/process/20250818/">18 August 2025 W3C Process Document</a>.
 </p>
 
-<p>
-	[STATUSTEXT]
+
+[STATUSTEXT]

--- a/boilerplate/dap/status-WD.include
+++ b/boilerplate/dap/status-WD.include
@@ -78,5 +78,5 @@
   This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/policies/process/20250818/">18 August 2025 W3C Process Document</a>.
 </p>
 
-<p>
-	[STATUSTEXT]
+
+[STATUSTEXT]


### PR DESCRIPTION
The `[STATUSTEXT]` macro was injected inside an unclosed `<p>` element in all 7 dap status templates. This prevents use of block-level elements (e.g. `<div class="advisement">`) in `Status Text` metadata, as a `<div>` inside a `<p>` is invalid HTML.

**Fix:** close the process document `<p>` explicitly and move `[STATUSTEXT]` outside it, so block-level `Status Text` content renders correctly.

**Affects:** `status-CR`, `status-CRD`, `status-FPWD`, `status-WD`, `status-ED`, `status-NOTE`, `status-DISC`

Discovered while adding `.advisement` boxes to the SotD sections of 11 DAS WG specs (e.g. [w3c/accelerometer#84](https://github.com/w3c/accelerometer/pull/84)).