### PR TITLE
Add "ukltd" to doctypes.kdl

### DIFF
--- a/boilerplate/doctypes.kdl
+++ b/boilerplate/doctypes.kdl
@@ -384,3 +384,19 @@ org "aom" {
     status "WGA" "AOM Working Group Approved Draft"
     status "FD" "AOM Final Deliverable"
 }
+
+org "ukltd" {
+  group "ukltd"
+
+  status "DA" "Approved by Company Directors"
+  status "SA" "Approved by Company Shareholders"
+  status "DP" "Proposal by Company Directors for Shareholder Approval"
+  status "HA" "Approved by Senior Staff or Department Head"
+  status "DDA" "Draft for Approval by Company Directors"
+  status "DSA" "Draft for Approval by Company Shareholders"
+  status "DDP" "Draft for Proposal by Company Directors for Shareholder Approval"
+  status "DHA" "Draft for Approval by Senior Staff or Department Head"
+  status "NO" "Notice"
+  status "DNO" "Draft Notice"
+  status "D" "Draft"
+}


### PR DESCRIPTION
Intended to reflect common use cases for UK Private Limited Companies incorporated with the Companies Act 2006.

We would like to use bikeshed for our internal policies management. While we can override boilerplate with the *.include files just fine, we are struggling with the status field. Rather than creating a new org/group for our micro-entity and potentially opening the door for so many others to do the same, I'm taking a higher level approach that would cover most cases for UK private limited companies.

The statuses don't make any prescription about whether things are proposed/approved by written resolution or by board meeting and the companies act doesn't care either. The custom metadata fields with the ! prefix can address links to board minutes or references if that's required for anyone.

If it is possible to just do this locally and you don't want to merge this change then I would appreciate knowing where I can put a local doctypes.kdl and not have to upstream this.