### PR TITLE
adding boilerplate as ttwg for W3C Timed-Text WG

### DIFF
--- a/boilerplate/doctypes.kdl
+++ b/boilerplate/doctypes.kdl
@@ -142,6 +142,7 @@ org "w3c" {
     group "svg" type="wg" priv-sec=true
     group "tag" type="tag"
     group "texttracks" type="cg" priv-sec=true
+    group "ttwg" type="cg" priv-sec=true
     group "uievents" type="wg" priv-sec=true
     group "w3t" type=null
     group "wasm" type="wg"

--- a/boilerplate/ttwg/defaults.include
+++ b/boilerplate/ttwg/defaults.include
@@ -1,0 +1,3 @@
+{
+	"Mailing List Archives": "https://lists.w3.org/Archives/Public/public-tt/"
+}

--- a/boilerplate/ttwg/status-CR.include
+++ b/boilerplate/ttwg/status-CR.include
@@ -30,8 +30,11 @@
 </p>
 
 <p>
-  For this specification to exit the CR stage, at least 2 independent implementations of every feature defined in this specification 
-  need to be documented in the implementation report. 
+  For this specification to exit the CR stage, 
+  each normative feature is expected to meet the requirements set out in the 
+  <a href="https://www.w3.org/groups/wg/timed-text/charters/active/#advancement">charter of the Timed Text Working Group</a> 
+  to demonstrate adequate <a href="https://www.w3.org/policies/process/20250818/#implementation-experience">implementation experience</a>, 
+  and need to be documented in the implementation report. 
   The Working Group does not require that implementations are publicly available but encourages them to be so.
 </p>
 

--- a/boilerplate/ttwg/status-CR.include
+++ b/boilerplate/ttwg/status-CR.include
@@ -1,0 +1,51 @@
+<p>
+  <em>
+    This section describes the status of this document at the time of its publication. 
+    A list of current W3C publications and the latest revision of this technical report can be found in the 
+    <a href="https://www.w3.org/TR/">W3C standards and drafts index</a>.
+  </em>
+</p>
+
+<p>
+  This document was published by the <a href="https://www.w3.org/groups/wg/timed-text/"><abbr title="World Wide Web Consortium">W3C</abbr> Timed Text Working Group</a>
+  as a Candidate Recommendation Snapshot using the <a href='https://www.w3.org/policies/process/20250818/#recs-and-notes'>Recommendation track</a>. 
+  This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
+  This document will remain a Candidate Recommendation at least until <time class="status-deadline" datetime="[ISODEADLINE]">[DEADLINE]</time> 
+  in order to ensure the opportunity for wide review.
+</p>
+
+<p>
+  If you wish to make comments regarding this document, please send them to <a href="mailto:public-tt@w3.org?subject=%5B[SHORTNAME]%5D">public-tt@w3.org</a>
+  (<a href="mailto:public-tt-request@w3.org?subject=subscribe">subscribe</a>, <a href="http://lists.w3.org/Archives/Public/public-tt/">archives</a>) 
+  with <code>&#x5B;[SHORTNAME]&#x5D;</code> at the start of your email’s subject.
+  All comments are welcome.
+</p>
+
+<p>
+  Publication as a Candidate Recommendation does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members. 
+  A Candidate Recommendation Snapshot has received <a href="https://www.w3.org/policies/process/20250818/#dfn-wide-review">wide review</a>, 
+  is intended to gather implementation experience, 
+  and has commitments from Working Group members 
+  to <a href="https://www.w3.org/policies/patent-policy/#sec-Requirements">royalty-free licensing</a> for implementations.
+</p>
+
+<p>
+  For this specification to exit the CR stage, at least 2 independent implementations of every feature defined in this specification 
+  need to be documented in the implementation report. 
+  The Working Group does not require that implementations are publicly available but encourages them to be so.
+</p>
+
+<p>
+  This document was produced by a group operating under the <a href="https://www.w3.org/policies/patent-policy/20200915/">W3C Patent Policy</a>.
+  W3C maintains a <a rel="disclosure" href="https://www.w3.org/groups/wg/timed-text/ipr">public list of any patent disclosures</a> 
+  made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. 
+  An individual who has actual knowledge of a patent that the individual believes contains <a href="https://www.w3.org/policies/patent-policy/20200915/#def-essential">Essential Claim(s)</a> 
+  must disclose the information in accordance with <a href="https://www.w3.org/policies/patent-policy/20200915/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
+</p>
+
+<p>
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/policies/process/20250818/">18 August 2025 W3C Process Document</a>.
+</p>
+
+[STATUSTEXT]
+

--- a/boilerplate/ttwg/status-CRD.include
+++ b/boilerplate/ttwg/status-CRD.include
@@ -1,0 +1,49 @@
+<p>
+  <em>
+    This section describes the status of this document at the time of its publication. 
+    A list of current W3C publications and the latest revision of this technical report can be found in the 
+    <a href="https://www.w3.org/TR/">W3C standards and drafts index</a>.
+  </em>
+</p>
+
+<p>
+  This document was published by the <a href="https://www.w3.org/groups/wg/timed-text/"><abbr title="World Wide Web Consortium">W3C</abbr> Timed Text Working Group</a>
+  as a Candidate Recommendation Draft using the <a href='https://www.w3.org/policies/process/20250818/#recs-and-notes'>Recommendation track</a>. 
+  This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
+</p>
+
+<p>
+  If you wish to make comments regarding this document, please send them to <a href="mailto:public-tt@w3.org?subject=%5B[SHORTNAME]%5D">public-tt@w3.org</a>
+  (<a href="mailto:public-tt-request@w3.org?subject=subscribe">subscribe</a>, <a href="http://lists.w3.org/Archives/Public/public-tt/">archives</a>) 
+  with <code>&#x5B;[SHORTNAME]&#x5D;</code> at the start of your email’s subject.
+  All comments are welcome.
+</p>
+
+<p>
+  Publication as a Candidate Recommendation does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members. 
+  A Candidate Recommendation Draft integrates changes from the previous Candidate Recommendation that the Working Group intends to 
+  include in a subsequent Candidate Recommendation Snapshot. 
+  This is a draft document and may be updated, replaced, or obsoleted by other documents at any time. 
+  It is inappropriate to cite this document as other than a work in progress.
+</p>
+
+<p>
+  For this specification to exit the CR stage, at least 2 independent implementations of every feature defined in this specification 
+  need to be documented in the implementation report. 
+  The Working Group does not require that implementations are publicly available but encourages them to be so.
+</p>
+
+<p>
+  This document was produced by a group operating under the <a href="https://www.w3.org/policies/patent-policy/20200915/">W3C Patent Policy</a>.
+  W3C maintains a <a rel="disclosure" href="https://www.w3.org/groups/wg/timed-text/ipr">public list of any patent disclosures</a> 
+  made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. 
+  An individual who has actual knowledge of a patent that the individual believes contains <a href="https://www.w3.org/policies/patent-policy/20200915/#def-essential">Essential Claim(s)</a> 
+  must disclose the information in accordance with <a href="https://www.w3.org/policies/patent-policy/20200915/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
+</p>
+
+<p>
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/policies/process/20250818/">18 August 2025 W3C Process Document</a>.
+</p>
+
+[STATUSTEXT]
+

--- a/boilerplate/ttwg/status-CRD.include
+++ b/boilerplate/ttwg/status-CRD.include
@@ -28,8 +28,11 @@
 </p>
 
 <p>
-  For this specification to exit the CR stage, at least 2 independent implementations of every feature defined in this specification 
-  need to be documented in the implementation report. 
+  For this specification to exit the CR stage, 
+  each normative feature is expected to meet the requirements set out in the 
+  <a href="https://www.w3.org/groups/wg/timed-text/charters/active/#advancement">charter of the Timed Text Working Group</a> 
+  to demonstrate adequate <a href="https://www.w3.org/policies/process/20250818/#implementation-experience">implementation experience</a>, 
+  and need to be documented in the implementation report. 
   The Working Group does not require that implementations are publicly available but encourages them to be so.
 </p>
 

--- a/boilerplate/ttwg/status-ED.include
+++ b/boilerplate/ttwg/status-ED.include
@@ -1,0 +1,41 @@
+<p>
+  <em>
+    This section describes the status of this document at the time of its publication. 
+    A list of current W3C publications and the latest revision of this technical report can be found in the 
+    <a href="https://www.w3.org/TR/">W3C standards and drafts index</a>.
+  </em>
+</p>
+
+<p>
+  This document was published by the <a href="https://www.w3.org/groups/wg/timed-text/"><abbr title="World Wide Web Consortium">W3C</abbr> Timed Text Working Group</a>
+  as a Editors' Draft. 
+  This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
+</p>
+
+<p>
+  If you wish to make comments regarding this document, please send them to <a href="mailto:public-tt@w3.org?subject=%5B[SHORTNAME]%5D">public-tt@w3.org</a>
+  (<a href="mailto:public-tt-request@w3.org?subject=subscribe">subscribe</a>, <a href="http://lists.w3.org/Archives/Public/public-tt/">archives</a>) 
+  with <code>&#x5B;[SHORTNAME]&#x5D;</code> at the start of your email’s subject.
+  All comments are welcome.
+</p>
+
+<p>
+  Publication as an Editors' Draft does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members. 
+  This is a draft document and may be updated, replaced, or obsoleted by other documents at any time. 
+  It is inappropriate to cite this document as other than a work in progress.
+</p>
+
+<p>
+  This document was produced by a group operating under the <a href="https://www.w3.org/policies/patent-policy/20200915/">W3C Patent Policy</a>.
+  W3C maintains a <a rel="disclosure" href="https://www.w3.org/groups/wg/timed-text/ipr">public list of any patent disclosures</a> 
+  made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. 
+  An individual who has actual knowledge of a patent that the individual believes contains <a href="https://www.w3.org/policies/patent-policy/20200915/#def-essential">Essential Claim(s)</a> 
+  must disclose the information in accordance with <a href="https://www.w3.org/policies/patent-policy/20200915/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
+</p>
+
+<p>
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/policies/process/20250818/">18 August 2025 W3C Process Document</a>.
+</p>
+
+[STATUSTEXT]
+

--- a/boilerplate/ttwg/status-FPWD.include
+++ b/boilerplate/ttwg/status-FPWD.include
@@ -30,12 +30,6 @@
 </p>
 
 <p>
-  For this specification to exit the CR stage, at least 2 independent implementations of every feature defined in this specification 
-  need to be documented in the implementation report. 
-  The Working Group does not require that implementations are publicly available but encourages them to be so.
-</p>
-
-<p>
   This document was produced by a group operating under the <a href="https://www.w3.org/policies/patent-policy/20200915/">W3C Patent Policy</a>.
   W3C maintains a <a rel="disclosure" href="https://www.w3.org/groups/wg/timed-text/ipr">public list of any patent disclosures</a> 
   made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. 

--- a/boilerplate/ttwg/status-FPWD.include
+++ b/boilerplate/ttwg/status-FPWD.include
@@ -1,0 +1,51 @@
+<p>
+  <em>
+    This section describes the status of this document at the time of its publication. 
+    A list of current W3C publications and the latest revision of this technical report can be found in the 
+    <a href="https://www.w3.org/TR/">W3C standards and drafts index</a>.
+  </em>
+</p>
+
+<p>
+  This document was published by the <a href="https://www.w3.org/groups/wg/timed-text/"><abbr title="World Wide Web Consortium">W3C</abbr> Timed Text Working Group</a>
+  as a First Public Working Draft using the <a href='https://www.w3.org/policies/process/20250818/#recs-and-notes'>Recommendation track</a>. 
+  This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
+</p>
+
+<p>
+  If you wish to make comments regarding this document, please send them to <a href="mailto:public-tt@w3.org?subject=%5B[SHORTNAME]%5D">public-tt@w3.org</a>
+  (<a href="mailto:public-tt-request@w3.org?subject=subscribe">subscribe</a>, <a href="http://lists.w3.org/Archives/Public/public-tt/">archives</a>) 
+  with <code>&#x5B;[SHORTNAME]&#x5D;</code> at the start of your email’s subject.
+  All comments are welcome.
+</p>
+
+<p>
+  This document is a <strong>First Public Working Draft</strong>.
+</p>
+
+<p>
+  Publication as a First Public Working Draft does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members. 
+  This is a draft document and may be updated, replaced, or obsoleted by other documents at any time. 
+  It is inappropriate to cite this document as other than a work in progress.
+</p>
+
+<p>
+  For this specification to exit the CR stage, at least 2 independent implementations of every feature defined in this specification 
+  need to be documented in the implementation report. 
+  The Working Group does not require that implementations are publicly available but encourages them to be so.
+</p>
+
+<p>
+  This document was produced by a group operating under the <a href="https://www.w3.org/policies/patent-policy/20200915/">W3C Patent Policy</a>.
+  W3C maintains a <a rel="disclosure" href="https://www.w3.org/groups/wg/timed-text/ipr">public list of any patent disclosures</a> 
+  made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. 
+  An individual who has actual knowledge of a patent that the individual believes contains <a href="https://www.w3.org/policies/patent-policy/20200915/#def-essential">Essential Claim(s)</a> 
+  must disclose the information in accordance with <a href="https://www.w3.org/policies/patent-policy/20200915/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
+</p>
+
+<p>
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/policies/process/20250818/">18 August 2025 W3C Process Document</a>.
+</p>
+
+[STATUSTEXT]
+

--- a/boilerplate/ttwg/status-WD.include
+++ b/boilerplate/ttwg/status-WD.include
@@ -1,0 +1,47 @@
+<p>
+  <em>
+    This section describes the status of this document at the time of its publication. 
+    A list of current W3C publications and the latest revision of this technical report can be found in the 
+    <a href="https://www.w3.org/TR/">W3C standards and drafts index</a>.
+  </em>
+</p>
+
+<p>
+  This document was published by the <a href="https://www.w3.org/groups/wg/timed-text/"><abbr title="World Wide Web Consortium">W3C</abbr> Timed Text Working Group</a>
+  as a Working Draft using the <a href='https://www.w3.org/policies/process/20250818/#recs-and-notes'>Recommendation track</a>. 
+  This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
+</p>
+
+<p>
+  If you wish to make comments regarding this document, please send them to <a href="mailto:public-tt@w3.org?subject=%5B[SHORTNAME]%5D">public-tt@w3.org</a>
+  (<a href="mailto:public-tt-request@w3.org?subject=subscribe">subscribe</a>, <a href="http://lists.w3.org/Archives/Public/public-tt/">archives</a>) 
+  with <code>&#x5B;[SHORTNAME]&#x5D;</code> at the start of your email’s subject.
+  All comments are welcome.
+</p>
+
+<p>
+  Publication as a Working Draft does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members. 
+  This is a draft document and may be updated, replaced, or obsoleted by other documents at any time. 
+  It is inappropriate to cite this document as other than a work in progress.
+</p>
+
+<p>
+  For this specification to exit the CR stage, at least 2 independent implementations of every feature defined in this specification 
+  need to be documented in the implementation report. 
+  The Working Group does not require that implementations are publicly available but encourages them to be so.
+</p>
+
+<p>
+  This document was produced by a group operating under the <a href="https://www.w3.org/policies/patent-policy/20200915/">W3C Patent Policy</a>.
+  W3C maintains a <a rel="disclosure" href="https://www.w3.org/groups/wg/timed-text/ipr">public list of any patent disclosures</a> 
+  made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. 
+  An individual who has actual knowledge of a patent that the individual believes contains <a href="https://www.w3.org/policies/patent-policy/20200915/#def-essential">Essential Claim(s)</a> 
+  must disclose the information in accordance with <a href="https://www.w3.org/policies/patent-policy/20200915/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
+</p>
+
+<p>
+  This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/policies/process/20250818/">18 August 2025 W3C Process Document</a>.
+</p>
+
+[STATUSTEXT]
+

--- a/boilerplate/ttwg/status-WD.include
+++ b/boilerplate/ttwg/status-WD.include
@@ -26,12 +26,6 @@
 </p>
 
 <p>
-  For this specification to exit the CR stage, at least 2 independent implementations of every feature defined in this specification 
-  need to be documented in the implementation report. 
-  The Working Group does not require that implementations are publicly available but encourages them to be so.
-</p>
-
-<p>
   This document was produced by a group operating under the <a href="https://www.w3.org/policies/patent-policy/20200915/">W3C Patent Policy</a>.
   W3C maintains a <a rel="disclosure" href="https://www.w3.org/groups/wg/timed-text/ipr">public list of any patent disclosures</a> 
   made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. 


### PR DESCRIPTION
Added TTWG for bikeshed publication.
[WebVTT](https://www.w3.org/TR/webvtt1/) has moved from Text Track Que CG to TTWG (solely), and TTWG need to have its own boilerplate.

/cc @gkatsev @nigelmegitt 