### PR TITLE
Fix trailing comma in WHATWG computed-metadata JSON

### DIFF
--- a/boilerplate-v1/org-whatwg/computed-metadata-LS-COMMIT.include
+++ b/boilerplate-v1/org-whatwg/computed-metadata-LS-COMMIT.include
@@ -7,7 +7,7 @@
   ],
   "!Commits": [
     "<a href='https://github.com/whatwg/[SHORTNAME]/commits'>GitHub whatwg/[SHORTNAME]/commits</a>",
-    "<a href='https://[SHORTNAME].spec.whatwg.org/' id=commit-snapshot-link>Go to the living standard</a>",
+    "<a href='https://[SHORTNAME].spec.whatwg.org/' id=commit-snapshot-link>Go to the living standard</a>"
   ],
   "!Tests": "<a href='https://github.com/web-platform-tests/wpt/tree/master/[SHORTNAME]'>web-platform-tests [SHORTNAME]/</a> (<a href='https://github.com/web-platform-tests/wpt/labels/[SHORTNAME]'>ongoing work</a>)",
   "Warning": "obsolete",

--- a/boilerplate-v1/org-whatwg/computed-metadata-LS-PR.include
+++ b/boilerplate-v1/org-whatwg/computed-metadata-LS-PR.include
@@ -7,7 +7,7 @@
   ],
   "!Commits": [
     "<a href='https://github.com/whatwg/[SHORTNAME]/commits'>GitHub whatwg/[SHORTNAME]/commits</a>",
-    "<a href='https://[SHORTNAME].spec.whatwg.org/' id=commit-snapshot-link>Go to the living standard</a>",
+    "<a href='https://[SHORTNAME].spec.whatwg.org/' id=commit-snapshot-link>Go to the living standard</a>"
   ],
   "!Tests": "<a href='https://github.com/web-platform-tests/wpt/tree/master/[SHORTNAME]'>web-platform-tests [SHORTNAME]/</a> (<a href='https://github.com/web-platform-tests/wpt/labels/[SHORTNAME]'>ongoing work</a>)",
   "Warning": "custom",

--- a/boilerplate-v1/org-whatwg/computed-metadata.include
+++ b/boilerplate-v1/org-whatwg/computed-metadata.include
@@ -7,7 +7,7 @@
   ],
   "!Commits": [
     "<a href='https://github.com/whatwg/[SHORTNAME]/commits'>GitHub whatwg/[SHORTNAME]/commits</a>",
-    "<a href='/commit-snapshots/[COMMIT-SHA]/' id=commit-snapshot-link>Snapshot as of this commit</a>",
+    "<a href='/commit-snapshots/[COMMIT-SHA]/' id=commit-snapshot-link>Snapshot as of this commit</a>"
   ],
   "!Tests": "<a href='https://github.com/web-platform-tests/wpt/tree/master/[SHORTNAME]'>web-platform-tests [SHORTNAME]/</a> (<a href='https://github.com/web-platform-tests/wpt/labels/[SHORTNAME]'>ongoing work</a>)",
   "Text Macro": "H1 [SPECTITLE]"


### PR DESCRIPTION
Follow-up to #200, which removed the Twitter link from the WHATWG `!Commits` array but left a trailing comma behind. The three affected files now contain invalid JSON:

```json
"!Commits": [
    "<a href='...'>GitHub whatwg/[SHORTNAME]/commits</a>",
    "<a href='...' id=commit-snapshot-link>Go to the living standard</a>",
  ],
```

Spec Generator uses strict JSON parsing, so this currently breaks PR previews and commit snapshots for every WHATWG spec — `Title`, `Logo`, and `H1` text macros all fail to resolve. Example failure: https://github.com/whatwg/url/actions/runs/28430528547/job/84243858651

Files fixed:
- `boilerplate-v1/org-whatwg/computed-metadata.include`
- `boilerplate-v1/org-whatwg/computed-metadata-LS-PR.include`
- `boilerplate-v1/org-whatwg/computed-metadata-LS-COMMIT.include`

Validated with `python3 -m json.tool` on all four `computed-metadata*.include` files in `org-whatwg/`.