### PR TITLE
Lint *.include files that should parse as JSON

### DIFF
--- a/.github/workflows/lint-includes.yml
+++ b/.github/workflows/lint-includes.yml
@@ -1,0 +1,27 @@
+name: Lint *.include JSON
+
+on:
+  push:
+    paths:
+      - "boilerplate-v1/**/*.include"
+      - ".github/workflows/lint-includes.yml"
+      - ".github/workflows/lint/lint-includes.py"
+  pull_request:
+    paths:
+      - "boilerplate-v1/**/*.include"
+      - ".github/workflows/lint-includes.yml"
+      - ".github/workflows/lint/lint-includes.py"
+  workflow_dispatch: {}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Lint *.include JSON
+      run: python .github/workflows/lint/lint-includes.py

--- a/.github/workflows/lint/lint-includes.py
+++ b/.github/workflows/lint/lint-includes.py
@@ -1,0 +1,38 @@
+"""Validate that JSON-shaped *.include files actually parse as JSON.
+
+Some boilerplate *.include files (computed-metadata, defaults) are JSON
+documents containing [TEXT-MACROS] inside string literals. They must be valid
+JSON before macro substitution, otherwise Bikeshed/Spec Generator fails with
+"Error loading computed-metadata JSON" and the affected spec cannot build.
+
+This script finds every *.include whose first non-whitespace character is "{"
+and validates it as strict JSON.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def main():
+    root = Path(__file__).resolve().parent.parent.parent.parent / "boilerplate-v1"
+    failures = []
+    checked = 0
+    for path in sorted(root.rglob("*.include")):
+        text = path.read_text(encoding="utf-8")
+        if text.lstrip().startswith("{"):
+            checked += 1
+            try:
+                json.loads(text)
+            except json.JSONDecodeError as e:
+                failures.append((path.relative_to(root.parent), e))
+
+    print(f"Checked {checked} JSON-shaped *.include files.")
+    for path, err in failures:
+        print(f"::error file={path}::{err}")
+    if failures:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Several `*.include` files (`computed-metadata*`, `defaults*`) are JSON documents containing `[TEXT-MACROS]` inside string literals. They need to be valid JSON before macro substitution; otherwise Bikeshed / W3C Spec Generator fails with `Error loading computed-metadata JSON` and downstream specs cannot build.

This is what happened with #200 / #202: a trailing-comma slipped past review and broke spec generation for every WHATWG spec until #202 landed.

This PR adds a small workflow that finds every `*.include` whose first non-whitespace character is `{` and validates it with `json.loads()`. The set of files currently caught:

- 4 × `computed-metadata*.include` (org-whatwg, org-w3c/csswg, default)
- 9 × `defaults*.include` (across several orgs)
- *(57 total across `boilerplate-v1/` after de-duplicating by path)*

Locally I verified the linter:
- catches the original #200 regression (re-injected the trailing comma → exit 1, annotated with `::error file=...::`)
- passes against current `main`

The workflow only triggers when `*.include` files or the linter itself change, mirroring `lint-doctypes.yml`.

(Drive-by observation, not addressed here: `lint-doctypes.yml`'s `paths:` filter still points at the pre-restructure `boilerplate/doctypes.kdl`, not `boilerplate-v1/...`, so it never actually runs on PRs touching that file. Happy to fix in a separate PR if useful.)