### PR TITLE
Add W3C Credentials CG (w3c-ccg) to doctypes

### DIFF
--- a/boilerplate-v1/doctypes.kdl
+++ b/boilerplate-v1/doctypes.kdl
@@ -144,6 +144,7 @@ org "w3c" {
     group "texttracks" type="cg" priv-sec=true
     group "ttwg" type="cg" priv-sec=true
     group "uievents" type="wg" priv-sec=true
+    group "w3c-ccg" type="cg"
     group "w3t" type=null
     group "wasm" type="wg"
     group "web-bluetooth-cg" type="cg" priv-sec=true


### PR DESCRIPTION
### What

Adds `group "w3c-ccg" type="cg"` to the `w3c` org in `boilerplate-v1/doctypes.kdl`.

### Why

Specs of the W3C Credentials Community Group use `Group: w3c-ccg` together with
`Status: w3c/CG-DRAFT`. Older Bikeshed accepted this — our spec at
https://ownyourdata.github.io/oydid/ was published that way. The value is absent
from this repo, so those documents now abort with:

FATAL ERROR: Unknown Group 'w3c-ccg'. See docs for recognized Group values.


### Verification

Tested locally with Bikeshed 7.1.1 against
https://github.com/OwnYourData/oydid/blob/main/docs/index.bs:

- with this one line added, the build succeeds and produces the full document
  including title, editors and the "Draft Community Group Report" status line
- building unpatched with `--die-on=nothing` produces byte-identical output
  (76223 bytes, `cmp` clean), so the group is already handled correctly
  everywhere else — only the registry entry is missing

No boilerplate folder is needed; the `org-w3c` defaults cover this group.

This PR is **finished**, not a draft.
